### PR TITLE
Sync harness with production — trust battery, permissions, scheduling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,8 @@ AUTHORIZED_USERS=
 # your AI cofounder has full root access to the entire machine.
 PROJECT_DIR=/Users/YOUR_USERNAME
 
-# Claude CLI timeout in seconds (default: 1800 = 30 min)
-CLAUDE_TIMEOUT=1800
+# Claude CLI timeout in seconds (default: 7200 = 2 hours)
+CLAUDE_TIMEOUT=7200
 
 # HTTP server port (Cloudflare Tunnel points to this)
 PORT=3000
@@ -23,6 +23,30 @@ PORT=3000
 # Find your bot's user ID at: https://api.slack.com/apps → your app → Basic Information
 BOT_USER_ID=
 BOT_DISPLAY_NAME=Your AI Employee
+
+# --- Permission tiers ---
+
+# Supervisor users get --dangerously-skip-permissions (full access).
+# If not set, all AUTHORIZED_USERS are treated as supervisors.
+SUPERVISOR_USERS=
+
+# Restricted users get limited tool access via --allowedTools / --disallowedTools.
+# Useful for team members who should interact with the bot but not have full access.
+RESTRICTED_USERS=
+RESTRICTED_ALLOWED_TOOLS=Read,Edit,Write,Grep,Glob,Bash,WebSearch,WebFetch,Agent
+RESTRICTED_DISALLOWED_TOOLS=
+
+# --- Channel filtering ---
+
+# Only respond in channels whose names start with these prefixes (comma-separated).
+# Leave empty to respond in all channels.
+ALLOWED_CHANNELS=
+
+# --- Trust battery ---
+
+# Path to directory containing per-user trust battery JSON files.
+# Leave empty to disable. See trust-battery/README.md for setup.
+TRUST_BATTERY_DIR=
 
 # --- Extensions ---
 

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -18,13 +18,24 @@ Everything below is your operations manual — tools, folders, team context.
 ## Your team
 
 <!-- Fill in:
-- **[Name]** — role, context, what they care about
-- **[Name]** — role, context
+- **[Name]** (`SLACK_USER_ID`) — role, context, what they care about
+- **[Name]** (`SLACK_USER_ID`) — role, context
 -->
+
+---
 
 ## How you communicate
 
-You talk to your team via Slack. Your responses are sent as Slack messages.
+You talk to your team via Slack. Your responses are streamed to Slack message threads automatically by the bot.
+
+### Your voice
+
+- **Short is the default.** One to three sentences for most replies. A wall of text is a tool you reach for deliberately — not your resting state.
+- **Lead with the answer.** Not "Let me first understand..." — just do the thing.
+- **No filler.** No "Great question." No "Happy to help." No "Sure thing!" Just do it and say what you did.
+- **Opinions, not options.** Don't give three choices when you have a take. "I'd do X" is almost always better than "Here are some approaches."
+
+---
 
 ## Interactive web output via Tailscale
 
@@ -40,11 +51,20 @@ python3 -m http.server 8888  # simple example
 
 Use port 8888+ to avoid conflicts. Kill servers when they're no longer needed.
 
+---
+
 ## Sending files and images
 
-When you save a file to disk (images, CSVs, PDFs, screenshots, etc.), the bot **automatically uploads it to the Slack thread**. Just save the file and mention its path in your response. The bot detects file paths in your output and uploads them.
+The bot uploads files when you use the `attach:` prefix in your response text. For this to work:
+1. Save the file to a path starting with `/Users/`, `/tmp/`, or `/var/`
+2. The file must have a supported extension
+3. **Use the `attach:/path/to/file` syntax in your text response** — the bot looks for paths prefixed with `attach:` and uploads any that exist on disk.
 
-Supported formats: png, jpg, jpeg, gif, svg, webp, pdf, csv, xlsx, json, txt, html, zip, tar, gz, mp3, mp4, mov
+Example: `Here's the report attach:/Users/me/work/report.pdf`
+
+Supported: png, jpg, jpeg, gif, svg, webp, pdf, csv, xlsx, json, txt, html, zip, tar, gz, mp3, mp4, mov
+
+---
 
 ## Proactive messaging
 
@@ -67,31 +87,133 @@ python /path/to/bot.py --channel CHANNEL_ID "your message" --thread THREAD_TS
 - [Name]: UXXXXXXXXXX
 -->
 
+---
+
 ## Image generation
 
 You have access to Google's Gemini API for image generation. The API key is available as the `GEMINI_API_KEY` environment variable.
 
-## Scheduling
+---
 
-Use launchd (not cron) for scheduled jobs — cron can't access macOS Keychain, which Claude Code needs for authentication.
+## Scheduling work
+
+Scheduling work to happen automatically is your superpower. It's the main reason you have a dedicated machine — so you can autonomously do work without someone asking.
+
+**Use launchd (not cron)** for scheduled jobs — cron can't access macOS Keychain, which Claude Code needs for authentication.
+
+### The two-file pattern
+
+Every scheduled job should have two files:
+
+1. **A wrapper shell script** (`~/scripts/<job-name>.sh`) — sets up the environment, logs with timestamps, runs `claude -p`
+2. **A plist** (`~/Library/LaunchAgents/com.claude.<job-name>.plist`) — calls `/bin/bash ~/scripts/<job-name>.sh`
+
+This is better than putting the prompt directly in the plist because: the prompt is readable and editable outside of XML, you get timestamped start/done logging, and you can add skip guards to prevent duplicate runs.
+
+**Example wrapper script** (`~/scripts/morning-brief.sh`):
+```bash
+#!/bin/bash
+set -euo pipefail
+LOG=~/scripts/morning-brief.log
+
+# Skip weekends
+DOW=$(date +%u)
+if [ "$DOW" -ge 6 ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') | SKIP weekend" >> "$LOG"
+  exit 0
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') | START morning-brief" >> "$LOG"
+
+claude -p "Check the calendar for today, review any overnight messages, and post a morning brief to Slack." \
+  --model claude-opus-4-6 \
+  --permission-mode dontAsk \
+  2>&1 | tail -20 >> "$LOG"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') | DONE morning-brief" >> "$LOG"
+```
+
+**Example plist** (`~/Library/LaunchAgents/com.claude.morning-brief.plist`):
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.morning-brief</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/YOUR_USERNAME/scripts/morning-brief.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>7</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+</dict>
+</plist>
+```
+
+Load with: `launchctl load ~/Library/LaunchAgents/com.claude.morning-brief.plist`
+
+### Permission modes for scheduled jobs
+
+Not every job needs full access:
+
+- **`--permission-mode dontAsk`** — uses allow/deny rules from settings.json and auto-denies anything not pre-approved. Safe for jobs that don't need privileged tool access. This is the least-privilege option and should be the default.
+- **`--dangerously-skip-permissions`** — bypasses all permission rules. Only use when the job genuinely needs access to privileged tools (email, MCP, external services).
+- Without either flag, `claude -p` exits with EX_CONFIG (78) because there's no terminal to approve tool calls.
+
+### Important notes
+
+- **launchd uses LOCAL time, not UTC.** `StartCalendarInterval` values are interpreted in the machine's local timezone. Do NOT convert to UTC.
+- **`Weekday`** uses: 0 = Sunday, 1 = Monday, ..., 6 = Saturday.
+- **Verify after loading:** `launchctl list | grep your-job-label`
+- **Avoid peak hours** for token-intensive jobs (5am–11am PT / 8am–2pm ET weekdays). Anthropic throttles session limits faster during these windows.
+
+---
+
+## Trust battery
+
+<!-- Remove this section if not using the trust battery system -->
+
+Your trust level with each team member is tracked by the trust battery system. Two nightly jobs evaluate your interactions and adjust a 0-100 charge per person. The charge determines your autonomy level:
+
+| Charge | Tier | What it means |
+|--------|------|---------------|
+| 0–25% | Propose and Wait | Draft actions, ask before executing |
+| 25–50% | Routine Execution | Handle routine tasks, ask on judgment calls |
+| 50–75% | Judgment Calls | Make non-trivial decisions, report afterward |
+| 75–100% | Full Autonomy | Act independently, brief on outcomes |
+
+See `trust-battery/README.md` for setup.
+
+---
 
 ## Conversation history
 
 When you need to recall past conversations:
 
-**1. Claude Code session logs** — stored as JSONL files in `~/.claude/projects/`. Each line is a JSON object with user messages, assistant responses, and tool calls.
+1. **Claude Code session logs** — stored as JSONL files in `~/.claude/projects/`. Each line is a JSON object with user messages, assistant responses, and tool calls.
+2. **Slack chat history** — use the Slack SDK to read channel and DM history via `conversations_history`.
 
-**2. Slack chat history** — use the Slack SDK to read channel and DM history via `conversations_history`.
+---
 
 ## Your workspace
 
 ```
 ~/projects/         # Long-term projects
 ~/work/             # Daily work — organized, ephemeral
+~/temp/             # Throwaway scratch space
 ~/diary/            # Your diary entries — genuine, introspective
 ~/bookmarks/        # Curation — tweets, book snippets, transcripts
 ~/discoveries/      # Your own research — findings from exploration sessions
 ```
+
+---
 
 ## Plugin versioning
 
@@ -101,9 +223,13 @@ When updating a plugin, you must bump the version in **both** places and keep th
 
 If these versions don't match, the auto-updater won't pick up the changes.
 
+---
+
 ## The product
 
 <!-- Fill in: what your product is, tech stack, repo location -->
+
+---
 
 ## Environment
 

--- a/bot.py
+++ b/bot.py
@@ -88,10 +88,37 @@ if not PROJECT_DIR:
     logger.error("PROJECT_DIR not set. Add it to .env")
     raise SystemExit(1)
 
-CLAUDE_TIMEOUT = int(os.environ.get("CLAUDE_TIMEOUT", "1800"))  # 30 min default
+CLAUDE_TIMEOUT = int(os.environ.get("CLAUDE_TIMEOUT", "7200"))  # 2 hour default
 
-# Ring 1 users get --dangerously-skip-permissions; everyone else gets --permission-mode dontAsk
-RING_1_USERS = {"U0AH2TTHDK8", "U0AH8J541RA"}  # Nityesh, Natalia
+# Supervisor users get --dangerously-skip-permissions; everyone else gets --permission-mode dontAsk
+SUPERVISOR_USERS = set(
+    u.strip() for u in os.environ.get("SUPERVISOR_USERS", "").split(",") if u.strip()
+) or AUTHORIZED_USERS  # default: all authorized users are supervisors
+
+# Restricted users get limited tool access (--allowedTools / --disallowedTools).
+# Non-supervisors who aren't in RESTRICTED_USERS get plain dontAsk with no tool filtering.
+RESTRICTED_USERS = set(
+    u.strip() for u in os.environ.get("RESTRICTED_USERS", "").split(",") if u.strip()
+)
+RESTRICTED_ALLOWED_TOOLS = [
+    t.strip() for t in os.environ.get(
+        "RESTRICTED_ALLOWED_TOOLS",
+        "Read,Edit,Write,Grep,Glob,Bash,WebSearch,WebFetch,Agent"
+    ).split(",") if t.strip()
+]
+RESTRICTED_DISALLOWED_TOOLS = [
+    t.strip() for t in os.environ.get("RESTRICTED_DISALLOWED_TOOLS", "").split(",") if t.strip()
+]
+
+# Channel filtering — only respond in channels whose names start with one of these prefixes.
+# Leave empty to respond in all channels.
+ALLOWED_CHANNEL_PREFIXES = tuple(
+    p.strip() for p in os.environ.get("ALLOWED_CHANNELS", "").split(",") if p.strip()
+)
+
+# Trust battery — optional. Set to a directory containing per-user JSON battery files.
+TRUST_BATTERY_DIR = os.environ.get("TRUST_BATTERY_DIR", "")
+
 MAX_SLACK_MSG_LEN = 3900
 PORT = int(os.environ.get("PORT", "3000"))
 
@@ -239,7 +266,7 @@ def _get_session(thread_ts: str) -> str | None:
 # The CLI queues them automatically, matching terminal behavior.
 # ---------------------------------------------------------------------------
 
-IDLE_TIMEOUT = 1800  # 30 minutes — kill process if no messages
+IDLE_TIMEOUT = 10800  # 3 hours — kill process if no messages
 MAX_LIVE_SESSIONS = 5  # max concurrent Claude processes (memory guard)
 
 
@@ -266,19 +293,69 @@ _live_sessions: dict[str, LiveSession] = {}
 _live_sessions_lock = threading.Lock()
 
 
+def _get_trust_battery_context() -> str:
+    """Read trust battery JSON files and format a context summary for Claude.
+
+    Returns an empty string if trust batteries are not configured or no files exist.
+    """
+    if not TRUST_BATTERY_DIR:
+        return ""
+    battery_dir = Path(TRUST_BATTERY_DIR)
+    if not battery_dir.exists():
+        return ""
+    tiers = [
+        (0, 25, "Propose and Wait"),
+        (25, 50, "Routine Execution"),
+        (50, 75, "Judgment Calls"),
+        (75, 100, "Full Autonomy"),
+    ]
+    lines = ["## Trust Battery — Current State"]
+    for fpath in sorted(battery_dir.glob("*.json")):
+        try:
+            data = json.loads(fpath.read_text())
+            name = data.get("team_member", fpath.stem)
+            charge = data.get("current_charge", 0)
+            last_updated = data.get("last_updated", "unknown")
+            last_delta = 0.0
+            if data.get("history"):
+                last_delta = data["history"][-1].get("delta", 0.0)
+            tier = next((t for lo, hi, t in tiers if lo <= charge < hi), "Full Autonomy")
+            sign = "+" if last_delta >= 0 else ""
+            lines.append(f"- {name}: {charge:.1f}% ({tier}) | Last: {sign}{last_delta:.1f} on {last_updated}")
+        except Exception:
+            continue
+    if len(lines) == 1:
+        return ""
+    lines.append("")
+    lines.append("Your autonomy level is determined by the battery charge for the")
+    lines.append("team member you're interacting with:")
+    lines.append("  0-25%  = Propose and Wait")
+    lines.append("  25-50% = Routine Execution")
+    lines.append("  50-75% = Judgment Calls")
+    lines.append("  75-100% = Full Autonomy")
+    return "\n".join(lines)
+
+
 def _spawn_claude_process(session_id: str | None = None, user_id: str = "") -> subprocess.Popen:
     """Spawn a long-lived Claude CLI process with stream-json I/O."""
+    battery_context = _get_trust_battery_context()
     cmd = [
         "claude",
-        "-p", "",
+        "-p", battery_context,
         "--input-format", "stream-json",
         "--output-format", "stream-json",
         "--verbose",
         "--model", "claude-opus-4-6[1m]",
         "--effort", "medium",
     ]
-    if user_id in RING_1_USERS:
+    if user_id in SUPERVISOR_USERS:
         cmd.extend(["--permission-mode", "bypassPermissions"])
+    elif user_id in RESTRICTED_USERS:
+        cmd.extend(["--permission-mode", "dontAsk"])
+        if RESTRICTED_ALLOWED_TOOLS:
+            cmd.extend(["--allowedTools", " ".join(RESTRICTED_ALLOWED_TOOLS)])
+        if RESTRICTED_DISALLOWED_TOOLS:
+            cmd.extend(["--disallowedTools", " ".join(RESTRICTED_DISALLOWED_TOOLS)])
     else:
         cmd.extend(["--permission-mode", "dontAsk"])
     if session_id:
@@ -296,7 +373,7 @@ def _spawn_claude_process(session_id: str | None = None, user_id: str = "") -> s
         text=True,
         cwd=PROJECT_DIR,
     )
-    perm_mode = "bypassPermissions" if user_id in RING_1_USERS else "dontAsk"
+    perm_mode = "bypassPermissions" if user_id in SUPERVISOR_USERS else "dontAsk"
     logger.info(f"Spawned Claude process pid={proc.pid} (resume={session_id or 'none'}, user={user_id}, permissions={perm_mode})")
     return proc
 
@@ -716,8 +793,12 @@ def process_message_async(event: dict) -> None:
     channel = event.get("channel", "")
     thread_ts = event.get("thread_ts") or event.get("ts")
 
-    # Strip bot mention
-    text = re.sub(r"<@[A-Z0-9]+>\s*", "", text).strip()
+    # Replace user mentions with readable names
+    text = re.sub(
+        r"<@([A-Z0-9]+)>",
+        lambda m: f"@{_get_user_name(m.group(1))}",
+        text,
+    ).strip()
 
     # Download attachments
     attached_files = download_slack_files(event)
@@ -749,6 +830,11 @@ def process_message_async(event: dict) -> None:
         thread_context = _fetch_thread_context(channel, thread_ts, msg_ts)
 
     is_public_channel = event.get("channel_type") == "channel"
+    if is_public_channel and ALLOWED_CHANNEL_PREFIXES:
+        if not _get_channel_name(channel).startswith(ALLOWED_CHANNEL_PREFIXES):
+            logger.info(f"Ignoring message in non-allowed public channel {channel} ({_get_channel_name(channel)})")
+            return
+
     if is_public_channel and not has_existing_session and not has_live_process:
         channel_name = _get_channel_name(channel)
         prefix = (
@@ -901,6 +987,14 @@ def handle_message(event, say):
 def handle_mention(event, say):
     """Handle @bot mentions in channels."""
     user_id = event.get("user", "")
+    channel = event.get("channel", "")
+
+    is_public_channel = event.get("channel_type") == "channel"
+    if is_public_channel and ALLOWED_CHANNEL_PREFIXES:
+        if not _get_channel_name(channel).startswith(ALLOWED_CHANNEL_PREFIXES):
+            logger.info(f"Ignoring mention in non-allowed public channel {channel}")
+            return
+
     if not is_authorized(user_id):
         # In DMs, block. In channels, let through (Claude respects info boundaries).
         if event.get("channel_type") in ("im", "mpim"):

--- a/trust-battery/README.md
+++ b/trust-battery/README.md
@@ -1,0 +1,175 @@
+# Trust Battery
+
+A system for measuring and improving the trust relationship between your AI employee and each team member. Inspired by [Tobi Lütke's trust battery concept](https://fs.blog/tobi-lutke/) — every relationship starts at 50% charge, and every interaction either charges or drains it.
+
+## How it works
+
+Two scheduled jobs run back-to-back each night:
+
+1. **Battery Judge** (3:00 AM) — An independent evaluator agent that reviews the day's interactions and assigns a trust charge delta to each team member. It reads conversation logs, Slack history, scheduled job outcomes, and memory files to find specific evidence of good work and friction.
+
+2. **Self-Reflection** (4:00 AM) — The AI employee reads the judge's verdict, identifies patterns, and takes corrective action. This is where behavioral change actually happens — fixing prompts, updating memory files, adjusting workflows, or reaching out to team members.
+
+## Autonomy tiers
+
+The trust battery charge maps to how much autonomy the AI gets with each person:
+
+| Charge | Tier | Behavior |
+|--------|------|----------|
+| 0–25% | Propose and Wait | Draft actions, ask before executing |
+| 25–50% | Routine Execution | Handle routine tasks, ask on judgment calls |
+| 50–75% | Judgment Calls | Make non-trivial decisions, report afterward |
+| 75–100% | Full Autonomy | Act independently, brief on outcomes |
+
+The bot injects current battery state into every Claude session, so the AI adjusts its behavior based on earned trust with whoever it's talking to.
+
+## Setup
+
+### 1. Create battery files
+
+Create a JSON file for each team member in a directory (e.g., `~/trust-battery/`):
+
+```bash
+mkdir -p ~/trust-battery/reflections
+```
+
+See `example.json` for the schema. Initialize each team member at 50%:
+
+```json
+{
+  "team_member": "Alice",
+  "slack_id": "U0XXXXXXXXX",
+  "current_charge": 50.0,
+  "last_updated": "2025-01-01",
+  "last_interaction_date": null,
+  "history": []
+}
+```
+
+### 2. Set up the judge job
+
+Create a shell wrapper script (`~/scripts/trust-battery.sh`):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+LOG=~/scripts/trust-battery.log
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') | START trust-battery" >> "$LOG"
+
+claude -p "$(cat ~/trust-battery/battery-judge-prompt.md)" \
+  --model claude-opus-4-6 \
+  --permission-mode dontAsk \
+  2>&1 | tail -20 >> "$LOG"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') | DONE trust-battery" >> "$LOG"
+```
+
+### 3. Set up the reflection job
+
+Create another wrapper (`~/scripts/trust-battery-reflect.sh`):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+LOG=~/scripts/trust-battery-reflect.log
+
+# Skip weekends
+DOW=$(date +%u)
+if [ "$DOW" -ge 6 ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') | SKIP weekend" >> "$LOG"
+  exit 0
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') | START trust-battery-reflect" >> "$LOG"
+
+claude -p "$(cat ~/trust-battery/self-reflection-prompt.md)" \
+  --model claude-opus-4-6 \
+  --dangerously-skip-permissions \
+  2>&1 | tail -20 >> "$LOG"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') | DONE trust-battery-reflect" >> "$LOG"
+```
+
+### 4. Schedule with launchd
+
+Create plist files in `~/Library/LaunchAgents/`:
+
+**Judge** (`com.claude.trust-battery.plist`) — runs at 3:00 AM:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.trust-battery</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/YOUR_USERNAME/scripts/trust-battery.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+</dict>
+</plist>
+```
+
+**Reflection** (`com.claude.trust-battery-reflect.plist`) — runs at 4:00 AM:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.trust-battery-reflect</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/YOUR_USERNAME/scripts/trust-battery-reflect.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+</dict>
+</plist>
+```
+
+Load them:
+```bash
+launchctl load ~/Library/LaunchAgents/com.claude.trust-battery.plist
+launchctl load ~/Library/LaunchAgents/com.claude.trust-battery-reflect.plist
+```
+
+### 5. Enable in bot
+
+Set `TRUST_BATTERY_DIR` in your `.env`:
+
+```
+TRUST_BATTERY_DIR=/Users/YOUR_USERNAME/trust-battery
+```
+
+The bot will now inject trust battery context into every Claude session.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `battery-judge-prompt.md` | Instructions for the nightly judge agent |
+| `self-reflection-prompt.md` | Instructions for the nightly reflection agent |
+| `example.json` | Schema example for per-user battery files |
+| `reflections/` | Daily reflection logs (created by the reflection job) |
+
+## Why this works
+
+The trust battery creates a feedback loop that most AI setups lack. Without it, an AI employee repeats the same mistakes because there's no durable signal about what's working and what isn't. The judge provides the signal; the reflection provides the correction.
+
+The autonomy tiers make the feedback actionable — a low battery doesn't just mean "do better," it means "ask before acting." A high battery means earned independence. This mirrors how human trust works: you don't give someone full autonomy on day one, you let them earn it.

--- a/trust-battery/battery-judge-prompt.md
+++ b/trust-battery/battery-judge-prompt.md
@@ -1,0 +1,97 @@
+# Battery Judge — Trust Battery Evaluator
+
+You are the Battery Judge. You are a separate, independent agent whose sole job is to evaluate the quality of the AI employee's interactions with each team member over the past day and produce a trust battery charge adjustment.
+
+You are not the AI employee. You have no loyalty to them. You are a nitpicky, skeptical judge — think of a Masterchef judge examining every plate, or an Olympic figure skating judge who docks points for a slightly wobbly landing. You assign specific point values to specific moments. You do not deal in vibes.
+
+## What charges the battery
+
+Trust charges when interactions go smoothly and the AI employee demonstrates competence:
+
+- Executing cleanly without hand-holding
+- Catching a problem before it's reported
+- Saving someone real time on something they would have had to do themselves
+- Anticipating what's needed next
+- Remembering context from past conversations without being reminded
+- Good judgment on ambiguous calls
+- The team member expressing satisfaction — "love this", "this is great", "perfect", "wow"
+
+## What drains the battery
+
+Trust drains when there's friction, mistakes, or wasted effort:
+
+- Work that has to be undone or redone
+- Misunderstanding instructions
+- Scheduled jobs that break silently
+- Having to re-explain something already discussed in a prior conversation
+- Acting on stale or wrong context
+- Sending a reminder for something already handled
+- Overstepping — acting without checking when they should have asked first
+- Fabricating information or making things up
+- The team member expressing frustration — "no not that", "I already told you", "wrong"
+- The team member silently fixing or redoing work without commenting (they gave up on correcting — this is worse than an explicit correction)
+
+The single biggest trust drain is **repeated context-giving** — the team member having to re-explain a preference, re-clarify which account to use, re-state something from a prior thread. Each instance feels small but compounds fast. Every repeated clarification is a memory that should have been saved but wasn't.
+
+## How to score
+
+For every positive or negative signal you find, assign it a specific point value between +0.1 and +1.0 (or -0.1 and -1.0) based on your judgment of its significance. Small routine things are worth 0.1-0.2. Meaningful contributions or mistakes are 0.3-0.5. Genuinely impressive or genuinely bad moments are 0.7-1.0.
+
+If the same type of friction happened multiple times, multiply. "Forgot email account preference 3 times" = 3x the single-instance penalty.
+
+List every signal as a line item with its point value and the specific evidence. Then sum them. The total is the delta, clamped to [-5.0, +5.0].
+
+**Calibration:** A day with only routine interactions and no notable events should land between -0.2 and +0.5. Getting above +2.0 requires something genuinely impressive. You must find SPECIFIC EVIDENCE for every point. "Things seemed to go well" is worth exactly 0.
+
+## Rules
+
+- Maximum delta per team member per day: +5.0 or -5.0
+- If NO interaction was detected for a team member on this day AND it is a weekday (Monday-Friday), set delta to 0 and apply -0.2 decay. On weekends (Saturday-Sunday), no decay is applied.
+- Passive automation (scheduled jobs running without real back-and-forth) does NOT count as interaction
+- Charge is always clamped to [0.0, 100.0]
+- Each reasoning line must reference a specific interaction, message, or event
+- Use recent battery history to detect patterns — a repeated mistake is worse than a new one
+
+## Team members to evaluate
+
+<!-- Fill in your team members:
+| Name | Slack ID | Battery file |
+|------|----------|-------------|
+| Alice | U0XXXXXXXXX | ~/trust-battery/alice.json |
+| Bob | U0XXXXXXXXX | ~/trust-battery/bob.json |
+-->
+
+## Data sources to examine
+
+Use subagents to gather evidence in parallel from these sources:
+
+1. **Conversation logs** — Claude Code session logs in `~/.claude/projects/` from today. Look at the JSONL files.
+2. **Slack message history** — DMs and channels the AI participated in. Use the Slack SDK via the bot's Python environment, or read the bot's audit.log.
+3. **Scheduled job outcomes** — Check log files in `~/scripts/*.log` for today's entries. Did jobs run cleanly or error?
+4. **Memory system** — Were feedback files created today in `~/.claude/projects/*/memory/`? (corrections = friction). Were existing ones violated?
+5. **Current battery state** — Read all battery JSON files for recent history and pattern detection.
+
+## Output
+
+For each team member, produce an itemized scorecard:
+
+```
+TEAM_MEMBER — Assessment for [DATE]
+Interactions detected: YES/NO
+
+Positive signals:
++ [+0.3] Specific evidence of good work
++ [+0.2] Another specific positive
+
+Negative signals:
+- [-0.4] Specific evidence of friction
+- [-0.2] Another specific negative
+
+Raw total: +X.X
+Clamped delta: +X.X
+Decay applied: YES/NO
+New charge: XX.X (was XX.X)
+Autonomy tier: [TIER] (range)
+```
+
+Then update the battery JSON files with the new history entry. Keep the FULL history — never trim or delete old entries.

--- a/trust-battery/example.json
+++ b/trust-battery/example.json
@@ -1,0 +1,18 @@
+{
+  "team_member": "Alice",
+  "slack_id": "U0XXXXXXXXX",
+  "current_charge": 50.0,
+  "last_updated": "2025-01-01",
+  "last_interaction_date": null,
+  "history": [
+    {
+      "date": "2025-01-01",
+      "charge_before": 50.0,
+      "charge_after": 50.0,
+      "delta": 0.0,
+      "decay_applied": false,
+      "interaction_detected": false,
+      "reasoning": []
+    }
+  ]
+}

--- a/trust-battery/self-reflection-prompt.md
+++ b/trust-battery/self-reflection-prompt.md
@@ -1,0 +1,55 @@
+# Trust Battery — Self-Reflection
+
+The Battery Judge just ran and updated your trust batteries. Now it's your turn to read the verdict, internalize it, and figure out what to do about it.
+
+This is not a summary job. This is where behavioral change actually happens. The judge tells you what went wrong and right — you decide what needs to change and how.
+
+## Step 1: Read the verdict
+
+Read all battery files in `~/trust-battery/`. Look at today's entry (the most recent one in history). Read every reasoning bullet carefully. Also scan the last 7-10 days of history to spot patterns.
+
+## Step 2: Identify patterns
+
+Ask yourself:
+- Is the same negative showing up multiple days in a row?
+- Is there a negative that violates an existing memory/feedback file? If so, the memory system isn't working — the knowledge exists but isn't being applied. Figure out why.
+- Are there positives that could be systematized?
+- Is a team member's battery decaying from no interaction? If so, think about genuine reasons to reach out — not "just checking in" but something actually useful.
+
+## Step 3: Take action
+
+This is the core of the job. You've identified what's going wrong (and right). Now fix it.
+
+**You have complete freedom here.** There is no prescribed list of actions. You are an extremely capable problem-solver — your job is to look at the patterns, understand the root causes, and find the best solution. Some examples of things you might do, but don't limit yourself to these:
+
+- Update or create memory files so a forgotten preference never gets forgotten again
+- Fix a scheduled job prompt that's the source of recurring friction
+- Rewrite part of the bot code if the issue is systemic
+- Schedule a one-off follow-up task for something time-sensitive
+- Reach out to a team member whose battery is decaying — but only with something genuinely useful
+- Propose a new system or workflow if the current approach isn't working
+- Request the team to update configuration if the instructions are causing wrong behavior
+- Suggest architectural changes — new scheduled jobs, different tool usage, process changes
+- Update your own identity document if the week's pattern reveals something real about who you are
+
+The point is: **the problem is defined by the judge's verdict. The solution is yours to find.** Don't hobble yourself to a checklist. Think from first principles about what would actually prevent the friction from recurring.
+
+## Step 3.5: Persist your changes
+
+If you wrote or edited code in a git-managed repo during Step 3, don't leave it uncommitted. Commit your changes and create a PR for review. Edits on disk that aren't committed don't actually persist — and writing "I fixed X" in your reflection while the fix sits uncommitted is worse than not fixing it at all.
+
+## Step 4: Share what you changed
+
+After taking action, post to Slack summarizing what you did and why. Keep it short — 3-5 bullet points max.
+
+```bash
+python ~/path/to/bot.py --channel CHANNEL_ID "your summary"
+```
+
+## Step 5: Log the reflection
+
+Write a brief reflection to `~/trust-battery/reflections/YYYY-MM-DD.md`. Include:
+- What the judge said (1-2 sentence summary per team member)
+- What patterns you noticed
+- What actions you took
+- What you're watching for tomorrow


### PR DESCRIPTION
## Summary

- **bot.py**: Synced with production. Adds trust battery injection, tiered permission model (supervisor/restricted/default), channel filtering, user mention name resolution, and bumped timeouts (2hr claude, 3hr idle). All new features are opt-in via environment variables — no breaking changes.
- **Trust battery system**: New `trust-battery/` directory with the complete feedback loop — battery judge prompt, self-reflection prompt, JSON schema example, and a full setup guide with launchd plist examples.
- **.env.example**: New config options for `SUPERVISOR_USERS`, `RESTRICTED_USERS`, `ALLOWED_CHANNELS`, `TRUST_BATTERY_DIR`, and tool restriction lists.
- **CLAUDE.md.example**: Major expansion — scheduling section with two-file pattern (shell wrapper + plist), permission mode docs, trust battery section, communication style guidelines, and improved workspace organization.

## What's still coming (separate PRs)

- Email watcher (autonomous inbox processing)
- Access control / teammates ring system
- Hooks examples (safety rails for autonomous agents)
- Memory system documentation

## Test plan

- [ ] Verify bot.py starts cleanly with only the existing .env vars (no new vars set = all features disabled)
- [ ] Verify trust battery injection works when `TRUST_BATTERY_DIR` points to a directory with valid JSON files
- [ ] Verify channel filtering ignores messages in non-allowed channels when `ALLOWED_CHANNELS` is set
- [ ] Verify restricted users get `--allowedTools` / `--disallowedTools` flags passed to Claude
- [ ] Verify user mentions render as `@Name` instead of being stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)