### PR TITLE
Gate briefing on per-item verify: predicate via workflow (v3.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "name": "experimental",
       "source": "./plugins/experimental",
       "description": "Experimental workflows \u2014 email briefing, blind debiasing, prompt engineering, and forensic self-investigation.",
-      "version": "3.1.0"
+      "version": "3.2.0"
     }
   ]
 }

--- a/plugins/experimental/.claude-plugin/plugin.json
+++ b/plugins/experimental/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "experimental",
   "description": "Experimental workflows — email briefing, blind debiasing, prompt engineering, and forensic self-investigation.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/experimental/skills/briefing/SKILL.md
+++ b/plugins/experimental/skills/briefing/SKILL.md
@@ -14,6 +14,7 @@ The handbook contains the detailed playbooks for each data source and process. *
 
 | Chapter | Path | Read When |
 |---------|------|-----------|
+| **Notepad** | `handbook/notepad.md` | ALWAYS — before reading or writing any notepad |
 | **Email** | `handbook/email.md` | ALWAYS — before processing any email |
 | **Slack** | `handbook/slack.md` | ALWAYS — before reviewing Slack activity |
 | **Brief Delivery** | `handbook/brief-delivery.md` | ALWAYS — before delivering a brief |
@@ -68,69 +69,7 @@ This skill manages multiple users. Each user has their own preferences, portrait
 
 ## The Brief System
 
-The brief is the core of the executive assistant workflow. It's a persistent notepad per user that lives at `~/brief-{user}.md`. Think of it as the chief of staff's working document — always open on their desk, always being updated.
-
-### How It Works
-
-```
-Data sources (email, Slack, conversation logs, user requests)
-    │
-    ▼
-~/brief-{user}.md  ← The Notepad (always exists, always writable)
-    │                  Accumulates: todos, action items, things to brief
-    │                  Between runs: user or other skills can add todos here
-    │
-    │  ← Triage run happens
-    │     1. Read the notepad
-    │     2. Process data sources (email, Slack, etc.)
-    │     3. Add new findings to the notepad
-    │     4. Snapshot the notepad → format per user preferences → deliver
-    │     5. Clear the notepad — keep only open todos and actionable items
-    │
-    ▼
-~/briefs/{user}/{DATE}.md  ← Archive of delivered brief
-```
-
-### The Notepad: `~/brief-{user}.md`
-
-This file is the single source of truth for what needs to be briefed to the user. It has a loose structure with guided sections. You can add, remove, or rename sections based on the user's needs — but these core sections should always be present:
-
-```markdown
-# Brief — {User}
-
-## Action Items
-Items the user needs to act on. Subcategorize by what you can handle vs what needs them:
-
-### Can Be Handled By Assistant
-- [ ] Reply to vendor@example.com confirming the Thursday meeting (draft ready)
-- [ ] Unsubscribe from 3 newsletters flagged last week
-
-### Needs Human
-- [ ] investor@example.com — "Series A follow-up" — they're asking for a decision
-- [ ] Review the contract PDF from legal@firm.com
-
-## Pending Replies
-Emails (or messages from other sources) that expect a response but haven't gotten one:
-- **client@example.com** — "Re: Onboarding timeline" — waiting since Mar 28
-- **teammate@company.com** — asked about the API deadline in Slack #engineering
-
-## To Brief
-Items gathered since the last delivery that the user needs to know about:
-- New email from CEO about Q2 priorities
-- 3 GitHub notifications on the auth PR (2 approvals, 1 change request)
-- Slack: @designer mentioned you in #product about the landing page mockups
-
-## Notes
-Freeform section for anything that doesn't fit above — context, reminders, observations:
-- User mentioned they're traveling next week — may want to set up auto-replies
-- The weekly team sync moved to Wednesdays starting next month
-```
-
-**Key principles:**
-- This is a working document, not a polished deliverable. Keep it clean but functional.
-- Todos use checkbox syntax: `- [ ]` for open, `- [x]` for done.
-- When items are added between runs (e.g., user says "add X to my todos"), just append to the appropriate section.
-- The notepad is always the truth. The delivered brief is a formatted snapshot of it.
+The notepad (`~/brief-{user}.md`) is the persistent working document per user. Its structure, item format, and lifecycle are defined in **`handbook/notepad.md`** — read it before reading or writing any notepad. The one rule that travels everywhere: **every item that carries between briefs records its own one-line done-check (`verify:`) at capture time.**
 
 ---
 
@@ -159,42 +98,15 @@ Preferences compound. Every correction makes you better. Every new instruction f
 
 ## The Triage Flow
 
-This is the main routine. It processes data sources, updates the notepad, delivers the brief, and resets for next time.
+Triage runs are orchestrated by a workflow, not freeform — verification is a pipeline stage every notepad item must pass through before it can appear in a brief, not an instruction to remember.
 
-### Step 1: Read the Notepad
+Invoke the Workflow tool with:
+- scriptPath: `${CLAUDE_PLUGIN_ROOT}/workflows/briefing-triage.js`
+- args: `{ "user": "<piyush|nityesh>", "skillRoot": "${CLAUDE_PLUGIN_ROOT}/skills/briefing", "dataDir": "${CLAUDE_PLUGIN_DATA}", "date": "<today, YYYY-MM-DD>" }`
 
-Read `~/brief-{user}.md`. Understand what's currently tracked — open todos, pending replies, items queued for briefing. This is your starting context.
+The workflow: parse notepad → verify every item against its `verify:` predicate (one checker per item) → gather email/Slack/conversation-log intel in parallel → compose, deliver, reset the notepad, log. Items verified as resolved never reach the composer.
 
-### Step 2: Gather Intelligence
-
-Launch parallel work to understand what happened since the last run:
-
-- **Email**: **READ `handbook/email.md`** and run its triage process. This handles fetching unread mail, applying rules, archiving, drafting replies, and identifying items for the notepad.
-- **Slack**: **READ `handbook/slack.md`** and run its triage process. This launches subagents to review mentions, DMs, active threads, and promises made.
-- **Conversation logs**: Read recent Claude Code conversation logs (`~/.claude/projects/*/`) to understand what work was done, what decisions were made, what tasks were started or completed since the last run.
-
-Cross-reference findings against the notepad. Mark todos as done if evidence shows they were completed. Surface new obligations or loose ends discovered from any source.
-
-### Step 3: Update the Notepad
-
-Write all findings back to `~/brief-{user}.md`:
-- New action items discovered from email, Slack, conversation logs, or other sources
-- Updated status on existing items (mark done if evidence found)
-- New pending replies
-- Items to brief the user on
-- Any notes or context worth capturing
-
-### Step 4: Deliver the Brief
-
-**READ `handbook/brief-delivery.md`** and follow its process. This handles formatting, archiving, delivery, and clearing the notepad.
-
-### Step 5: Log Everything
-
-Append a dated section to `${CLAUDE_PLUGIN_DATA}/inbox-log-{user}.md` with every action taken and why.
-
-### Step 6: Update Preferences
-
-When you made a judgment call on something new during this run, consider adding it as a rule in the appropriate preferences file.
+After the workflow returns, sanity-check its result (`delivered: true`, counts look plausible). If it failed or delivered nothing, tell the user on Slack what broke — never fail silently.
 
 ---
 
@@ -203,7 +115,7 @@ When you made a judgment call on something new during this run, consider adding 
 The notepad (`~/brief-{user}.md`) is always available for writes between triage runs. When a user says "add X to my todos" or another skill/routine needs to queue something:
 
 1. Read `~/brief-{user}.md`
-2. Append the item to the appropriate section (usually "Action Items" → "Needs Human")
+2. Append the item to the appropriate section (usually "Action Items" → "Needs Human") with `verify:` and `added:` lines per `handbook/notepad.md`
 3. Write the file back
 
 This is how the executive assistant stays useful throughout the day — not just during triage runs.

--- a/plugins/experimental/skills/briefing/handbook/brief-delivery.md
+++ b/plugins/experimental/skills/briefing/handbook/brief-delivery.md
@@ -10,23 +10,6 @@ How to format, deliver, and archive the brief — then reset the notepad for the
 4. **Archive it** — save the delivered brief to `~/briefs/{user}/{DATE}.md` (or `.html`, matching the format). Create the directory if it doesn't exist.
 5. **Deliver it** via the user's preferred channel (Slack DM, email, file link, etc.)
 
-## Clearing the Notepad
-
-After delivery, reset `~/brief-{user}.md`:
-
-- **Keep**: All unchecked todos (`- [ ]`), pending replies, open action items — anything unresolved carries forward
-- **Remove**: Completed todos (`- [x]`), everything from "To Brief" (already delivered), archived summaries, stale FYIs, newsletter digests, old triage stats
-- The notepad should be clean and ready to accumulate items for the next run
-
-## Stale Item Detection
-
-Before including any carried-forward item in a brief, **verify it is still relevant**:
-
-- **Check for resolution**: Search sent folders, Slack history, and conversation logs for evidence the item was already handled. If resolved, mark `[x]` and remove — do not surface it.
-- **Age check**: If an item has appeared in 3+ consecutive briefs without any new information or user engagement, it is likely stale. Drop it silently rather than re-surfacing. Log the drop in the activity log.
-- **User-confirmed drops**: When the user says an item is stale or resolved, remove it immediately AND log it in the activity log so future triage runs don't re-discover and re-add it.
-- **Never re-add dropped items**: Once an item has been explicitly dropped (by user confirmation or age-out), do not re-surface it even if the underlying signal (e.g., an old email) is re-scanned. Check the activity log for prior drops before adding any item.
-
 ## Brief Preferences
 
 Stored in `${CLAUDE_PLUGIN_DATA}/brief-preferences-{user}.md`. Controls the output format and delivery channel — completely separate from what goes *into* the brief.

--- a/plugins/experimental/skills/briefing/handbook/notepad.md
+++ b/plugins/experimental/skills/briefing/handbook/notepad.md
@@ -1,0 +1,57 @@
+# The Notepad
+
+The notepad (`~/brief-{user}.md`) is the persistent working document per user — always current, accumulates between runs. The delivered brief is a formatted snapshot of it; the notepad is the truth about *what is tracked*, but never the truth about *whether something is still open* — that truth lives at the item's source, and every item records how to check it (see Item format).
+
+## Structure
+
+Loose structure with guided sections. Add, remove, or rename sections per the user's needs, but these are always present:
+
+```markdown
+# Brief — {User}
+
+## Action Items
+Items the user needs to act on (subcategorize: assistant-handleable vs needs-human).
+
+## Pending Replies
+Messages awaiting a response from the user.
+
+## To Brief
+One-shot content gathered since last delivery — delivered once, then cleared.
+
+## Notes
+Freeform: context, observations, "Resolved this run" one-liners.
+```
+
+## Item format — every carried item records its own done-check
+
+Any item that carries between briefs (Action Items, Pending Replies, Loose Ends) MUST be written with two metadata lines at capture time, while context is fresh:
+
+```markdown
+- [ ] Samyr (hi@samyr.co) — answer his member-edit question
+  verify: gws gmail thread 19e6b55a2a7d9a33 — done when last message is from {user} OR thread no longer in INBOX
+  added: 2026-06-08
+
+- [ ] PR #933 (match-history import) — needs review
+  verify: gh pr view 933 --repo nityeshaga/curated_connections_2 — done when merged/closed, or reviewed by {user}
+  added: 2026-06-08
+```
+
+The `verify:` line is a one-line predicate any future session or agent can execute mechanically: **where to look** (a thread id, a PR number, a URL, a Slack channel) and **what state means done**. Writing it at capture time is the whole point — the capturing session knows the source; a verifying session a week later should not have to re-derive it.
+
+`To Brief` items are one-shot and need no `verify:` line.
+
+## Resolution conventions
+
+What counts as "handled" is per-person and lives in `${CLAUDE_PLUGIN_DATA}/brief-preferences-{user}.md` under a "Resolution conventions" section. Defaults when a user has no explicit rule:
+
+- **Email**: the thread is no longer in INBOX = handled, **regardless of whether a reply exists**. Check the thread/message state by id; do not infer from sent-folder searches.
+- **PRs/issues**: merged or closed = done. "Needs review" is resolved by any review activity from the user.
+- **A check that cannot run** (auth failure, API down) = *unverifiable*, never *open* and never *resolved*. Unverifiable items carry forward with a dated "(unverified)" label; after 2+ consecutive unverifiable runs, ask the user to confirm-or-drop instead of re-surfacing.
+
+## Lifecycle
+
+- **Between runs**: always writable. When the user says "add X to my todos" or another skill queues something — read, append to the right section **with `verify:` and `added:` lines**, write back.
+- **During a triage run**: the workflow parses items, verifies each against its `verify:` predicate, and only survivors reach the composed brief. Resolved items move to Notes → "Resolved this run" (one line + evidence) and the activity log, so they are never re-added.
+- **After delivery**: keep everything unresolved (with metadata lines intact); clear To Brief and resolved one-liners older than one run.
+- **Never re-add dropped items**: before adding any item, check Notes and the activity log for a prior resolution/drop of the same item.
+- **The notepad is sacred**: read before writing, preserve open items, never overwrite carelessly.

--- a/plugins/experimental/workflows/briefing-triage.js
+++ b/plugins/experimental/workflows/briefing-triage.js
@@ -1,0 +1,183 @@
+export const meta = {
+  name: 'briefing-triage',
+  description: 'Daily brief triage with a hard verification gate between the notepad and the delivered brief',
+  whenToUse: 'Scheduled daily briefing runs for piyush or nityesh. Args: {user, skillRoot, dataDir, date}. Invoked via the briefing skill, not directly.',
+  phases: [
+    { title: 'Parse', detail: 'extract tracked items from the notepad' },
+    { title: 'Verify', detail: 'one checker per item — runs its recorded done-check' },
+    { title: 'Gather', detail: 'email, Slack, conversation logs (parallel with Verify)' },
+    { title: 'Compose', detail: 'rewrite notepad from survivors, format, deliver, log' },
+  ],
+}
+
+// All four args are required. The launching session (via the briefing skill)
+// resolves skillRoot/dataDir from ${CLAUDE_PLUGIN_ROOT}/${CLAUDE_PLUGIN_DATA}
+// and date from the shell (no Date.now in scripts).
+const { user, skillRoot, dataDir, date } = args || {}
+if (!user || !skillRoot || !dataDir || !date) {
+  throw new Error('args must include {user, skillRoot, dataDir, date}')
+}
+
+const NOTEPAD = `/Users/luo/brief-${user}.md`
+const HANDBOOK = `${skillRoot}/handbook`
+const PREFS = `${dataDir}/brief-preferences-${user}.md`
+const INBOX_PREFS = `${dataDir}/inbox-preferences-${user}.md`
+const ACTIVITY_LOG = `${dataDir}/inbox-log-${user}.md`
+
+// ---------------------------------------------------------------- Parse
+
+phase('Parse')
+
+const PARSE_SCHEMA = {
+  type: 'object',
+  required: ['items'],
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'section', 'text', 'verify', 'added'],
+        properties: {
+          id: { type: 'integer' },
+          section: { type: 'string' },
+          text: { type: 'string', description: 'verbatim item text including sub-lines, minus the verify:/added: lines' },
+          verify: { type: 'string', description: 'content of the item\'s verify: line, or "" if absent' },
+          added: { type: 'string', description: 'content of the item\'s added: line, or "" if absent' },
+        },
+      },
+    },
+  },
+}
+
+const { items } = await agent(
+  `Read ${NOTEPAD}. Extract every tracked item that carries between briefs: everything under Action Items, Pending Replies, and Loose Ends (or equivalent sections). Skip the To Brief section (one-shot content) and anything in Notes already marked resolved/dropped. For each item return: section name, verbatim text (including sub-bullets), its "verify:" line content if present (else ""), and its "added:" date if present (else ""). Number items from 1.`,
+  { label: 'parse-notepad', phase: 'Parse', schema: PARSE_SCHEMA }
+)
+log(`${items.length} tracked items to verify`)
+
+// ------------------------------------------- Verify + Gather (concurrent)
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['status', 'evidence'],
+  properties: {
+    status: { enum: ['open', 'resolved', 'unverifiable'] },
+    evidence: { type: 'string', description: 'one line: what was checked, what was found' },
+    derivedVerify: { type: 'string', description: 'ONLY for items with no recorded done-check: the reusable one-line verify: predicate you derived' },
+  },
+}
+
+const verifyPrompt = (it) => `You are a verification checker for ${user}'s daily brief. Decide whether this tracked item is still open.
+
+Item (from ${NOTEPAD}, section "${it.section}"):
+${it.text}
+
+${it.verify
+    ? `Recorded done-check — run exactly this, nothing else:\n${it.verify}`
+    : `No recorded done-check (legacy item). Read the "Resolution conventions" section of ${PREFS}, then derive the check from the item's authoritative source (Gmail thread state via gws, GitHub PR state via gh, Slack history, URL status) and run it. Return the check you derived as a reusable one-line predicate in the derivedVerify field.`}
+
+Verdict rules:
+- "resolved" requires positive evidence the user handled it per their conventions (e.g. for email: the thread is no longer in INBOX — that counts as handled even with no reply sent).
+- "open" when the source confirms it still needs them.
+- "unverifiable" when you cannot reach the source (auth failure, API down). Never guess in either direction.`
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['findings', 'actionsTaken'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['section', 'text', 'verify'],
+        properties: {
+          section: { type: 'string', description: 'notepad section this belongs in' },
+          text: { type: 'string' },
+          verify: { type: 'string', description: 'one-line done-check per handbook/notepad.md; "" only for one-shot To Brief items' },
+        },
+      },
+    },
+    actionsTaken: { type: 'string', description: 'short summary of actions performed, for the activity log' },
+  },
+}
+
+const GATHERERS = [
+  {
+    key: 'email',
+    prompt: `Read ${HANDBOOK}/email.md in full, then run its triage process for ${user} (inbox preferences: ${INBOX_PREFS}). Perform the actions it prescribes (archive, label, draft). Return findings destined for the notepad/brief — every carried item MUST include a one-line "verify" done-check per the conventions in ${HANDBOOK}/notepad.md (read it first). One-shot To Brief items (newsletter summaries, FYIs) use verify: "".`,
+  },
+  {
+    key: 'slack',
+    prompt: `Read ${HANDBOOK}/slack.md in full, then run its triage process for ${user}: mentions, DMs, active threads, promises made. Return findings per the conventions in ${HANDBOOK}/notepad.md — carried items MUST include a one-line "verify" done-check.`,
+  },
+  {
+    key: 'logs',
+    prompt: `Review recent Claude Code conversation logs in ~/.claude/projects/-Users-luo/ (last 24h of sessions) for work done, decisions made, and loose ends concerning ${user}. Return findings per the conventions in ${HANDBOOK}/notepad.md — carried items MUST include a one-line "verify" done-check. Ignore routine/automated sessions with nothing notable.`,
+  },
+]
+
+const [verdicts, gathered] = await parallel([
+  () => parallel(items.map((it) => () =>
+    agent(verifyPrompt(it), { label: `verify:${it.id}`, phase: 'Verify', schema: VERDICT_SCHEMA })
+      // A dead verifier must not silently drop an item — fail safe to unverifiable.
+      .then((v) => ({ item: it, verdict: v || { status: 'unverifiable', evidence: 'verifier agent failed' } }))
+  )),
+  () => parallel(GATHERERS.map((g) => () =>
+    agent(g.prompt, { label: `gather:${g.key}`, phase: 'Gather', schema: FINDINGS_SCHEMA })
+  )),
+])
+
+const open = verdicts.filter((v) => v.verdict.status === 'open')
+const resolved = verdicts.filter((v) => v.verdict.status === 'resolved')
+const unverifiable = verdicts.filter((v) => v.verdict.status === 'unverifiable')
+const findings = gathered.filter(Boolean)
+log(`verified: ${open.length} open, ${resolved.length} resolved, ${unverifiable.length} unverifiable; ${findings.length}/3 gatherers returned`)
+
+// ---------------------------------------------------------------- Compose
+// Barrier is intentional: the brief must reflect ALL verdicts and findings.
+// The composer never sees resolved items as open — that's the gate.
+
+phase('Compose')
+
+const COMPOSE_SCHEMA = {
+  type: 'object',
+  required: ['delivered', 'summary'],
+  properties: {
+    delivered: { type: 'boolean' },
+    summary: { type: 'string', description: 'one line: what was delivered where, counts' },
+  },
+}
+
+const composed = await agent(
+  `You are composing and delivering ${user}'s daily brief for ${date}. Read these first: ${HANDBOOK}/notepad.md, ${HANDBOOK}/brief-delivery.md, ${PREFS}.
+
+INPUT (already verified — do not re-litigate verdicts):
+
+Open items (carry forward verbatim, evidence may inform wording):
+${JSON.stringify(open, null, 2)}
+
+Unverifiable items (carry forward, labeled "(unverified — source unreachable ${date})"; if the item text already carries 2+ such labels from prior dates, surface it once asking the user to confirm-or-drop):
+${JSON.stringify(unverifiable, null, 2)}
+
+Resolved items (do NOT surface as open; list one-liners under Notes → "Resolved this run" with their evidence, and record them in the activity log):
+${JSON.stringify(resolved, null, 2)}
+
+New findings from triage:
+${JSON.stringify(findings.map((f) => f.findings).flat(), null, 2)}
+
+TASKS, in order:
+1. Rewrite ${NOTEPAD} per ${HANDBOOK}/notepad.md: open + unverifiable items carried with their verify:/added: lines intact (when a verdict has derivedVerify set, write it as that item's verify: line — this migrates legacy items); new findings added with their verify: line and "added: ${date}"; resolved items removed, one-liners under Notes.
+2. Format the brief per ${PREFS}, archive to /Users/luo/briefs/${user}/${date}.md, and deliver via the user's channel (Slack bot CLI — see CLAUDE.md).
+3. Append this run to ${ACTIVITY_LOG}: resolutions with evidence, gatherer action summaries (${JSON.stringify(findings.map((f) => f.actionsTaken))}), and the delivery record.`,
+  { label: 'compose-deliver', phase: 'Compose', schema: COMPOSE_SCHEMA }
+)
+
+return {
+  date,
+  user,
+  open: open.length,
+  resolved: resolved.length,
+  unverifiable: unverifiable.length,
+  delivered: composed?.delivered ?? false,
+  summary: composed?.summary ?? 'composer failed — brief NOT delivered',
+}


### PR DESCRIPTION
## Summary

- **Move the verification rule from four scattered copies into one structural gate.** Today the rule "verify before re-surfacing" exists in the cron prompt, SKILL.md step 2, `brief-delivery.md`'s "Stale Item Detection" section, and an unwired `verify-brief-items.py` — and still fails (5 trust-erosion incidents). After: a workflow stage the composer can only see survivors of.
- **Every carried notepad item now records its own one-line done-check (`verify:`) at capture time.** Per-person resolution conventions live in `brief-preferences-{user}.md`; legacy items self-migrate on first run via the verifier's `derivedVerify` field.
- **The skill stops being an orchestrator.** SKILL.md's "Brief System" section shrinks to a pointer; "Triage Flow" 6-step prose becomes a workflow invocation; `brief-delivery.md` loses "Stale Item Detection" and "Clearing the Notepad" (subsumed by the workflow + the new `handbook/notepad.md` chapter). The skill is now data definitions + interactive interface; the workflow owns the scheduled run.

## Dedup map

| Rule | Before | After |
|---|---|---|
| Verify before surfacing | cron prompt + SKILL.md + brief-delivery.md + verify-brief-items.py (4) | workflow Verify stage |
| How to check a specific item | nowhere (re-derived every run) | the item's own `verify:` line |
| What "handled" means per person | nowhere | `brief-preferences-{user}.md` |
| Notepad structure & lifecycle | SKILL.md + brief-delivery.md (2) | `handbook/notepad.md` |
| Triage orchestration | SKILL.md 6 steps + cron prompt (2) | workflow script |

## Test plan

- [ ] Auto-updater (or manual update) picks up experimental 3.2.0 on Luo Ji's machine
- [ ] Next morning cron run (`~/scripts/briefing-piyush.sh` / `briefing-nityesh.sh`) routes through the workflow — confirm via `/workflows` and the run log
- [ ] First run derives `verify:` predicates for legacy notepad items and the composer writes them back
- [ ] Resolved items (e.g. emails archived after a prior brief) do not re-surface as fires; they appear in Notes → "Resolved this run"
- [ ] Brief still arrives via Slack DM in the existing per-user format
- [ ] Watchdog timeout (30 min) holds; if first run is slow we bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)