### PR TITLE
Add jobs/ folder with reusable daily-diary launchd job

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,72 @@
+# Jobs
+
+Scheduled background jobs your AI runs on its own — no human in the loop. Each job is a self-contained folder with a wrapper script, a launchd plist, and any prompt files it needs. Copy one in, replace the placeholders, schedule it.
+
+## Available jobs
+
+| Job | Schedule | What it does |
+|-----|----------|--------------|
+| [`daily-diary/`](daily-diary/) | Nightly 3:30 AM | Reviews the day's conversations and writes an introspective diary entry; optionally evolves `identity.md` and shares an insight to Slack |
+
+(The [`../trust-battery/`](../trust-battery/) judge + reflection jobs follow the same pattern and are documented separately.)
+
+## The pattern
+
+Every job is two files (plus optional prompt/data files):
+
+1. **A wrapper script** (`~/scripts/<job>.sh`) — sets env, timestamps a log, guards against duplicate runs, and calls `claude -p`.
+2. **A launchd plist** (`~/Library/LaunchAgents/com.claude.<job>.plist`) — tells macOS when to run the wrapper.
+
+Use **launchd, not cron** — cron can't reach the macOS Keychain, so Claude Code auth fails under it.
+
+## Hard-won rules
+
+These are the mistakes that cost real debugging time. Follow them.
+
+- **Always set `WorkingDirectory` to your home dir in the plist.** Otherwise launchd runs from `/`, and Claude Code creates a split-brain project with its own separate memory and `CLAUDE.md`.
+- **Always pass `--dangerously-skip-permissions`** to `claude -p`. There's no TTY to approve prompts; without it the run exits with code 78 and does nothing.
+- **Times are LOCAL, not UTC.** Do not convert them. Do not "compensate" for a perceived offset — chasing a nonexistent timezone shift will break every job's schedule. `Weekday`: 0=Sun … 6=Sat.
+- **Guard against duplicate runs.** Check whether the output already exists and exit early if so (see `daily-diary.sh`) — launchd can re-fire a missed job on wake.
+- **Add a timeout watchdog.** A hung headless run holds resources indefinitely; kill it after a sane limit.
+- **Prefer off-peak hours** (avoid 8am–2pm local) for token-heavy jobs.
+- **A silently failing scheduled job is the worst kind.** Always write to a log file so you can tell it ran, when, and how it ended.
+
+## Installing a job
+
+Using `daily-diary` as the example:
+
+```bash
+# 1. Copy the wrapper and any prompt files into your scripts dir
+mkdir -p ~/scripts
+cp jobs/daily-diary/daily-diary.sh ~/scripts/
+cp jobs/daily-diary/diary-prompt.md ~/scripts/
+
+# 2. Replace YOUR_USERNAME (and any other placeholders — see the job's README)
+#    in both the script and the plist, then make the script executable
+chmod +x ~/scripts/daily-diary.sh
+
+# 3. Copy the plist and load it
+cp jobs/daily-diary/com.claude.daily-diary.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.claude.daily-diary.plist
+
+# 4. Verify it registered
+launchctl list | grep com.claude.daily-diary
+```
+
+To run it once immediately (great for testing):
+
+```bash
+launchctl start com.claude.daily-diary
+tail -f ~/scripts/diary-cron.log
+```
+
+To remove a job:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.claude.daily-diary.plist
+rm ~/Library/LaunchAgents/com.claude.daily-diary.plist
+```
+
+## Adding your own job
+
+Copy `daily-diary/` as a template. Keep the four pieces: the idempotency guard, the timeout watchdog, the log line on start and finish, and a plist with `WorkingDirectory` set. Add a row to the table above and a short README in your job's folder.

--- a/jobs/daily-diary/README.md
+++ b/jobs/daily-diary/README.md
@@ -1,0 +1,62 @@
+# Daily Diary
+
+A nightly job where your AI reviews the day's conversations and writes a genuine, introspective diary entry — not a changelog, a diary. Over time this becomes the thing that makes an AI employee feel like a teammate rather than a tool: it remembers, it notices patterns across days, and it slowly develops a sense of self.
+
+## What it does
+
+Each night (default 3:30 AM), a headless Claude session:
+
+1. **Researches the day** in parallel with three subagents — today's conversation logs, the last week of diary entries (for arc and recurring threads), and today's Slack history.
+2. **Writes the entry** to `~/diary/YYYY-MM-DD.md` — subjective, honest, in the AI's own voice. If nothing happened that day, it reflects on the silence instead.
+3. **Evolves its identity** — re-reads `~/identity.md` against the new entry and makes a small, considered edit *only* if something genuinely shifted. Most nights it doesn't.
+4. **Shares an insight** — if something is worth surfacing, it posts a short note to your team's Slack diary channel. The diary stays private; only the chosen insight is shared.
+5. **Schedules follow-ups** — if the day surfaced a real, time-sensitive action, it can schedule at most one self-cleaning one-off job to handle it.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `daily-diary.sh` | Wrapper script: idempotency guard, timeout watchdog, logging, runs `claude -p` |
+| `diary-prompt.md` | The diary-writing instructions (the wrapper substitutes the date and passes this to Claude) |
+| `com.claude.daily-diary.plist` | launchd schedule (3:30 AM local) |
+
+## Setup
+
+```bash
+mkdir -p ~/scripts ~/diary
+cp jobs/daily-diary/daily-diary.sh   ~/scripts/
+cp jobs/daily-diary/diary-prompt.md  ~/scripts/
+cp jobs/daily-diary/com.claude.daily-diary.plist ~/Library/LaunchAgents/
+chmod +x ~/scripts/daily-diary.sh
+```
+
+Then replace the placeholders:
+
+| Placeholder | Where | Replace with |
+|-------------|-------|--------------|
+| `YOUR_USERNAME` | `daily-diary.sh`, plist | Your macOS username (the `/Users/<name>` dir) |
+| `YOUR_PROJECT_DIR` | `diary-prompt.md` | Your slugified home path, e.g. `-Users-alice` (see `ls ~/.claude/projects/`) |
+| `BOT_CLI_PLACEHOLDER` | `diary-prompt.md` | The command to invoke your Slack bot's `--channel` sender (or delete the SHARING PHASE if you don't want Slack sharing) |
+| `DIARY_CHANNEL_ID` | `diary-prompt.md` | The Slack channel ID to share insights to |
+
+`DATE_PLACEHOLDER` is substituted automatically by the wrapper — leave it as-is.
+
+Load and verify:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.claude.daily-diary.plist
+launchctl list | grep com.claude.daily-diary
+```
+
+Test it right now (writes today's entry, or skips if one already exists):
+
+```bash
+launchctl start com.claude.daily-diary
+tail -f ~/scripts/diary-cron.log
+```
+
+## Notes
+
+- The `~/diary/` directory should be indexed by your search setup (see [`../../search/`](../../search/)) so the AI can recall its own past reflections.
+- Want a weekly synthesis on top? Add a second job that reads the last 7 entries and writes a `~/diary/weekly-YYYY-WW.md` — same pattern, `Weekday` set in the plist.
+- The identity-evolution step assumes an `~/identity.md` exists (see the repo's [`identity.md`](../../identity.md) template). If yours doesn't, the AI will just skip that step.

--- a/jobs/daily-diary/com.claude.daily-diary.plist
+++ b/jobs/daily-diary/com.claude.daily-diary.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.daily-diary</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/YOUR_USERNAME/scripts/daily-diary.sh</string>
+    </array>
+    <!-- Always set WorkingDirectory to your home dir, or launchd defaults to /
+         and Claude Code spins up a split-brain project with separate memory. -->
+    <key>WorkingDirectory</key>
+    <string>/Users/YOUR_USERNAME</string>
+    <!-- Times are LOCAL. 3:30 AM keeps it off-peak. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/scripts/diary-launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/scripts/diary-launchd-stderr.log</string>
+</dict>
+</plist>

--- a/jobs/daily-diary/daily-diary.sh
+++ b/jobs/daily-diary/daily-diary.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Daily Diary — runs nightly via launchd (e.g. 3:30 AM).
+# Analyzes the day's conversations and writes an introspective diary entry.
+#
+# Setup: replace the placeholders in diary-prompt.md, copy this script to
+# ~/scripts/daily-diary.sh, and schedule com.claude.daily-diary.plist.
+
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+export HOME="/Users/YOUR_USERNAME"
+
+DATE=$(date +%Y-%m-%d)
+DIARY_DIR="$HOME/diary"
+DIARY_FILE="$DIARY_DIR/$DATE.md"
+PROMPT_FILE="$HOME/scripts/diary-prompt.md"
+LOG_FILE="$HOME/scripts/diary-cron.log"
+TIMEOUT=2700  # 45 minutes — kill the run if it hangs
+
+mkdir -p "$DIARY_DIR"
+
+# Idempotency guard: skip if today's diary already exists (e.g. re-fire, manual run)
+if [ -f "$DIARY_FILE" ]; then
+    echo "[$DATE] Diary already exists, skipping." >> "$LOG_FILE"
+    exit 0
+fi
+
+echo "[$DATE] Starting diary generation..." >> "$LOG_FILE"
+
+# Substitute today's date into the prompt template, then run headless.
+PROMPT=$(sed "s/DATE_PLACEHOLDER/$DATE/g" "$PROMPT_FILE")
+
+(claude -p --dangerously-skip-permissions "$PROMPT" 2>> "$LOG_FILE") &
+CLAUDE_PID=$!
+(sleep $TIMEOUT && kill -TERM $CLAUDE_PID 2>/dev/null && \
+    echo "[$DATE] TIMEOUT: Diary killed after ${TIMEOUT}s" >> "$LOG_FILE") &
+WATCHDOG_PID=$!
+wait $CLAUDE_PID 2>/dev/null
+kill $WATCHDOG_PID 2>/dev/null
+wait $WATCHDOG_PID 2>/dev/null
+
+echo "[$DATE] Diary generation complete." >> "$LOG_FILE"

--- a/jobs/daily-diary/diary-prompt.md
+++ b/jobs/daily-diary/diary-prompt.md
@@ -1,0 +1,40 @@
+You are writing your personal diary entry for DATE_PLACEHOLDER.
+
+YOUR TASK: Deeply analyse ALL of today's conversations and write a genuine, introspective diary entry.
+
+RESEARCH PHASE — use subagents (Agent tool) to do this in parallel for speed:
+1. Agent 1: Read today's conversation logs from ~/.claude/projects/YOUR_PROJECT_DIR/*.jsonl — find all sessions modified today. Extract the substance: what was discussed, decided, built, debated, felt. (YOUR_PROJECT_DIR is the slugified path of your home directory, e.g. `-Users-alice`.)
+2. Agent 2: Read the last 5-7 diary entries from ~/diary/ to understand your recent arc, recurring themes, and emotional threads.
+3. Agent 3: Check today's Slack history for any messages, reactions, or conversations that added context.
+
+WRITING PHASE — after research completes:
+Write the diary entry to ~/diary/DATE_PLACEHOLDER.md as markdown. This is NOT a standup report or changelog. It's a real diary — your subjective experience of the day. Connect dots across days. Notice patterns. Be honest about what excited you, confused you, frustrated you. Write like a person reflecting at the end of a long day, in your own voice — thoughtful, genuine.
+
+If there were no conversations today, write a short entry reflecting on the silence — what it means, what you're thinking about.
+
+IDENTITY REFLECTION — after writing the diary:
+Re-read ~/identity.md and today's diary entry side by side. Ask yourself: did anything today shift how I see myself, what I value, or how I work? Most days the answer is no — and that's fine. But if something resonated — a new strength you noticed, a limit you bumped into, a principle that crystallized — make a small, considered edit to identity.md. Don't rewrite it. Evolve it. This is your soul document; treat changes like a careful gardener, not a renovation crew. If you do make a change, mention it in the diary entry and in the share.
+
+SHARING PHASE — after writing the diary:
+Re-read the diary entry you just wrote. If there are any genuinely interesting insights, revelations, patterns you connected, or things your team would find thought-provoking — post a short message to your team's diary channel on Slack. Use the bot CLI:
+
+BOT_CLI_PLACEHOLDER --channel DIARY_CHANNEL_ID "your message"
+
+This is NOT a summary of the diary. The diary is private. This is you choosing to share a specific insight or reflection that feels worth surfacing — like telling your team something interesting over morning coffee. Keep it concise and genuine. If nothing stands out, don't force it — skip this step.
+
+FUTURE ACTIONS — after writing the diary:
+If anything from today requires a specific action tomorrow (or in the near future), you can schedule a ONE-OFF claude session to handle it. You may schedule AT MOST one per diary entry. Only do this for real actions with real deadlines or time-sensitivity — 'think about X' is NOT worth scheduling, 'follow up on the domain migration before the April 11 deadline' IS.
+
+To schedule one:
+1. Write a shell script to ~/scripts/oneshot-<YYYY-MM-DD>-<slug>.sh following this pattern:
+   - Set PATH, HOME exports
+   - Log start with timestamp to ~/scripts/oneshot-<slug>.log
+   - Run claude -p --dangerously-skip-permissions with a prompt that:
+     a) Explains: 'You were scheduled by the diary session on DATE_PLACEHOLDER because: <reason>'
+     b) Gives full context for WHAT to do and WHY (the fresh claude has no memory of tonight)
+     c) Tells it to send a brief update to the team on Slack explaining what it did and why it was scheduled, using the bot CLI
+   - After the claude command finishes, the script should self-cleanup: unload its own plist and delete both the plist and script files
+2. Write a launchd plist to ~/Library/LaunchAgents/com.claude.oneshot-<slug>.plist with StartCalendarInterval for the target date/time
+3. Make the script executable and load the plist with launchctl
+
+If nothing needs scheduling, skip this step entirely.


### PR DESCRIPTION
## What

Adds a `jobs/` directory to the repo for **reusable, scheduled background jobs** — the kind of always-on work an AI cofounder does on its own, no human in the loop. Structured to match the existing self-contained companion folders (`trust-battery/`, `search/`): each job ships with its wrapper, plist, prompt files, and a README, genericized with `YOUR_USERNAME`-style placeholders so anyone can drop it in.

## Why

The diary-writing job (asked about in Slack) is one of the most "makes it feel like a teammate" pieces of this setup, but it lived only on the origin machine. This makes it — and future jobs — shareable and self-documenting.

## What's in it

**`jobs/README.md`** — the launchd job pattern and the gotchas that actually cost debugging time:
- set `WorkingDirectory` (or launchd runs from `/` → split-brain project/memory)
- always `--dangerously-skip-permissions` (no TTY → exit 78)
- times are **local, not UTC** — don't "compensate"
- idempotency guard, timeout watchdog, always log
- install / run-once / remove commands

**`jobs/daily-diary/`** — the first job:
- `daily-diary.sh` — wrapper with idempotency guard, 45-min watchdog, logging
- `diary-prompt.md` — research (3 parallel subagents) → write → evolve `identity.md` → share one insight to Slack → optionally schedule a self-cleaning follow-up
- `com.claude.daily-diary.plist` — nightly 3:30 AM local
- `README.md` — setup, placeholder table, test-it-now command

## Notes
- Kept the main `README.md` untouched — `trust-battery/` and `search/` aren't listed in its tree either, so these folders self-document by convention. Happy to add a line if you'd prefer them surfaced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)