### PR TITLE
Fix repeated context notices when subagents run

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1628,12 +1628,25 @@ def handle_block_action(ack, body):
             log_unauthorized(body)
             return
 
+        atype = action.get("type", "")
         label = action.get("text", {}).get("text", "")
         value = action.get("value", "")
-        if action.get("type") == "static_select":
-            opt = action.get("selected_option", {})
+        if atype in ("static_select", "radio_buttons"):
+            opt = action.get("selected_option") or {}
             label = opt.get("text", {}).get("text", label)
             value = opt.get("value", value)
+        elif atype in ("checkboxes", "multi_static_select"):
+            opts = action.get("selected_options") or []
+            value = ", ".join(o.get("text", {}).get("text") or o.get("value", "") for o in opts)
+            label = label or "selection"
+        elif atype == "datepicker":
+            value = action.get("selected_date") or ""
+            label = label or "date"
+        elif atype == "timepicker":
+            value = action.get("selected_time") or ""
+            label = label or "time"
+        elif atype == "plain_text_input":
+            label = label or "text input"
         desc = f'"{label}"' if label else f"action {action.get('action_id', '?')}"
         if value and value != label:
             desc += f" (value: {value})"

--- a/bot.py
+++ b/bot.py
@@ -598,6 +598,11 @@ def _track_context(session: LiveSession, data: dict) -> None:
     Context shrinks when the CLI compacts the conversation — re-arm the
     thresholds then, so utilization gets re-announced on the way back up.
     """
+    # Subagent (Task) events stream through the same stdout with the
+    # subagent's own, much smaller context — counting them re-arms the
+    # threshold and re-fires the alert every turn. Main-loop events only.
+    if data.get("parent_tool_use_id"):
+        return
     usage = data.get("message", {}).get("usage") or {}
     ctx = (usage.get("input_tokens", 0)
            + usage.get("cache_read_input_tokens", 0)


### PR DESCRIPTION
Follow-up bugfix to #6, found in production within the hour: any thread that uses subagents got the same context notice re-posted after every message.

**Root cause:** subagent (Task) assistant events stream through the same stdout as the main loop, carrying the *subagent's* much smaller context footprint. `_track_context` read that dip as compaction, re-armed the threshold, and re-fired the alert on the next main-loop event — once per turn.

**Fix:** skip events with `parent_tool_use_id` (set on all subagent traffic, verified by capturing a live stream with a subagent: main 25k / subagent 8.7k interleaved). Replaying that captured stream through the fixed tracker across three simulated turns produces exactly one alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)