### PR TITLE
In-thread stop: bare 'stop' interrupts a running turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You (anywhere) → Slack → Cloudflare Tunnel → Your Mac → Claude Code CLI
 - **Streaming output** — real-time responses as Claude generates
 - **Native tables** — markdown tables in responses render as real Slack tables (Block Kit `markdown` block)
 - **Interactive buttons** — button clicks and menu picks route back into the thread's Claude session as messages, so your AI can offer approve/hold/snooze choices and act on the answer (requires Interactivity enabled in your Slack app config; Request URL = the same `/slack/events` endpoint)
+- **In-thread stop** — type a bare `stop` in a thread where the bot is mid-run to interrupt it (like Esc in the terminal); the session survives with full context, so your next message steers it in the new direction
 
 ## License
 

--- a/bot.py
+++ b/bot.py
@@ -1501,6 +1501,72 @@ def process_message_async(event: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# In-thread stop (the Esc key for Slack)
+# ---------------------------------------------------------------------------
+
+
+def _interrupt_session(session: LiveSession) -> bool:
+    """Send the CLI an interrupt (the programmatic Esc). True if the turn ended cleanly."""
+    try:
+        payload = json.dumps({"type": "control_request",
+                              "request_id": f"interrupt-{int(time.time() * 1000)}",
+                              "request": {"subtype": "interrupt"}})
+        with session.stdin_lock:
+            session.proc.stdin.write(payload + "\n")
+            session.proc.stdin.flush()
+    except Exception as e:
+        logger.warning(f"Interrupt write failed for {session.thread_ts}: {e}")
+    if session._turn_done.wait(timeout=5):
+        return True
+    # Interrupt didn't land — hard-kill; the thread resumes via --resume next message
+    try:
+        session.proc.terminate()
+    except Exception:
+        pass
+    session._turn_done.set()
+    return False
+
+
+def _maybe_stop_from_message(event: dict) -> bool:
+    """In-thread Esc: Slack blocks slash commands in thread reply boxes, so a
+    bare 'stop' (or 'esc') in a thread with a running turn interrupts it
+    instead of queueing as a normal message. Returns True if handled.
+
+    Exact-match only — sentences containing 'stop' pass through untouched,
+    and with no running turn the word falls through as a normal message.
+    Authorized users only: interrupting a run is a control action, even in
+    channels where unauthorized users may otherwise talk to the bot.
+    """
+    if not is_authorized(event.get("user", "")):
+        return False
+    text = re.sub(r"<@[A-Z0-9]+>", "", event.get("text", "")).strip().lower()
+    if text not in ("stop", "esc"):
+        return False
+    thread_ts = event.get("thread_ts") or event.get("ts")
+    with _live_sessions_lock:
+        session = _live_sessions.get(thread_ts)
+    if not session or session.proc.poll() is not None or not session.turn_lock.locked():
+        return False  # nothing running here — treat as a normal message
+
+    def _do_stop():
+        clean = _interrupt_session(session)
+        note = ("stopped mid-run — tell me where to go instead" if clean
+                else "had to hard-kill the process; the thread resumes with full context on your next message")
+        try:
+            slack_client.chat_postMessage(
+                channel=session.channel, thread_ts=session.thread_ts,
+                text=f"Stopped: {note}",
+                blocks=[{"type": "context", "elements": [
+                    {"type": "mrkdwn", "text": f":octagonal_sign: _{note}_"}]}],
+            )
+        except Exception:
+            pass
+
+    threading.Thread(target=_do_stop, daemon=True).start()
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Slack event handlers
 # ---------------------------------------------------------------------------
 
@@ -1537,6 +1603,10 @@ def handle_message(event, say):
             return
         log_unauthorized(event)
 
+    # In-thread Esc: bare "stop" while a turn is running interrupts it
+    if _maybe_stop_from_message(event):
+        return
+
     # Process async — return immediately so Slack gets its 200
     threading.Thread(target=process_message_async, args=(event,), daemon=True).start()
 
@@ -1560,6 +1630,10 @@ def handle_mention(event, say):
             say(text="I only respond to authorized users.", thread_ts=event.get("ts"))
             return
         log_unauthorized(event)
+
+    # "@bot stop" in a thread = in-thread Esc
+    if _maybe_stop_from_message(event):
+        return
 
     threading.Thread(target=process_message_async, args=(event,), daemon=True).start()
 


### PR DESCRIPTION
The Esc key for Slack. Typing a bare `stop` (or `esc`, mention optional) in a thread where the bot is mid-run interrupts the turn via a `control_request: interrupt` over the CLI's stdin — verified live: the turn ends in <1s and the session survives with full context, so the next message in the thread steers it in the new direction. 5s fallback: hard-kill + `--resume` on next message, so nothing is ever lost.

Why not a slash command: Slack blocks slash commands inside thread reply boxes, and the thread is exactly where you need the brake. (Tried, removed.)

Guardrails, unit-tested:
- exact match only — "stop the deploy" and other sentences pass through untouched
- idle thread → the word arrives as a normal message
- authorized users only — interrupting is a control action, even in channels where unauthorized users may otherwise talk to the bot

Running in production on the reference install; battle-tested by Nityesh before porting here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)