### PR TITLE
Mid-turn steering: talk to the bot while it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You (anywhere) → Slack → Cloudflare Tunnel → Your Mac → Claude Code CLI
 - **Native tables** — markdown tables in responses render as real Slack tables (Block Kit `markdown` block)
 - **Interactive buttons** — button clicks and menu picks route back into the thread's Claude session as messages, so your AI can offer approve/hold/snooze choices and act on the answer (requires Interactivity enabled in your Slack app config; Request URL = the same `/slack/events` endpoint)
 - **In-thread stop** — type a bare `stop` in a thread where the bot is mid-run to interrupt it (like Esc in the terminal); the session survives with full context, so your next message steers it in the new direction
+- **Mid-turn steering** — message a thread while the bot is mid-run and it sees your message at the next tool-call boundary, inside the same turn (like typing without Esc in the terminal); no more waiting for the whole task to finish before you can course-correct
 
 ## License
 

--- a/bot.py
+++ b/bot.py
@@ -403,6 +403,10 @@ class LiveSession:
     _on_text: callable = field(default=None, repr=False)
     # Event that signals when a turn (result) is complete
     _turn_done: threading.Event = field(default_factory=threading.Event)
+    # Eyes reactions from mid-turn steering messages, removed by the reader
+    # loop when the absorbing turn's result arrives. CPython list append/pop
+    # are atomic, so no extra lock for this traffic.
+    pending_reactions: list = field(default_factory=list)
     # Highest 100k context threshold already announced in the thread
     ctx_notified_level: int = 0
 
@@ -648,6 +652,13 @@ def _reader_loop(session: LiveSession) -> None:
                 if sid:
                     session.session_id = sid
                     _save_session(session.thread_ts, sid)
+                # Clear eyes reactions from steering messages this turn absorbed
+                while session.pending_reactions:
+                    ch, ts = session.pending_reactions.pop(0)
+                    try:
+                        slack_client.reactions_remove(channel=ch, name="eyes", timestamp=ts)
+                    except Exception:
+                        pass
                 session._turn_done.set()
 
     except Exception as e:
@@ -1441,6 +1452,22 @@ def process_message_async(event: dict) -> None:
     start = time.time()
     try:
         session = _get_or_create_live_session(thread_ts, channel, user_id=user_id)
+
+        # Real-time steering: a turn is already running in this thread — don't
+        # hold the message until it finishes. Write it to stdin now; the CLI
+        # delivers it at the next tool-call boundary inside the running turn,
+        # exactly like typing without Esc in interactive Claude Code. The
+        # running turn's on_text posts to this same thread, so replies route
+        # correctly. If the turn ends in the race window the message simply
+        # starts the next turn, and its eyes reaction is still drained by the
+        # reader on that turn's result. `stop`/`esc` remains the hard
+        # interrupt for aborting a slow tool call outright.
+        if session.turn_lock.locked():
+            _send_to_claude(session, text)
+            session.pending_reactions.append((reaction_channel, reaction_msg_ts))
+            audit_interaction(event, "(steered into running turn)", 0.0, session.session_id)
+            logger.info(f"Steering message injected mid-turn in thread {thread_ts}")
+            return
 
         # Acquire turn_lock — this serializes the send→wait cycle.
         # If another message is already being processed, we block here.


### PR DESCRIPTION
## What

Message a thread while the bot is mid-run and it now sees your message at the next tool-call boundary, **inside the same turn** — exactly like typing without pressing Esc in interactive Claude Code. Previously the bot held every new thread message until the running turn fully completed, so there was no way to course-correct in real time.

## How

The CLI already does the hard part: a user message written to a live stream-json process's stdin mid-turn is queued and delivered at the next tool-call boundary (verified empirically — a message sent during a 20s Bash sleep was answered within the same turn, single `result` event). The bot's `turn_lock` was the only thing withholding the message.

Change: when a message arrives for a thread whose `turn_lock` is held, write it straight to the session's stdin instead of blocking. The running turn's `on_text` callback already posts to the same thread, so replies route correctly.

Details:
- The steering message's :eyes: reaction is queued on `session.pending_reactions` and removed by the reader loop when the absorbing turn's `result` arrives.
- Race window: if the turn ends between the `locked()` check and the stdin write, the message simply starts the next turn; its reaction is still drained on that turn's result.
- `stop` / `esc` (in-thread stop, #8) remains the hard interrupt for when you want to abort a slow tool call rather than wait for it.

## Verified live

Running on Luo Ji's production bot: a 45s foreground task was steered 15s in with new information, and the single final reply incorporated it (old behavior would have produced two separate turns, the first answering "UNKNOWN").

🤖 Generated with [Claude Code](https://claude.com/claude-code)