### PR TITLE
Idle reaper: don't kill sessions that are still producing output

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -627,6 +627,11 @@ def _reader_loop(session: LiveSession) -> None:
             except json.JSONDecodeError:
                 continue
 
+            # Any output means the session is working — keep the idle reaper
+            # away even when no new message has arrived for a long time
+            # (e.g. a quiet multi-hour background workflow).
+            session.last_activity = time.time()
+
             msg_type = data.get("type")
 
             if msg_type == "system":


### PR DESCRIPTION
## What

`last_activity` was only updated when a message was **sent to** the process. A session quietly working past `IDLE_TIMEOUT` with no incoming messages — a long background workflow, a multi-agent fan-out — got killed mid-work by the idle cleanup. Ironically, pinging the bot "how's it going" was the thing keeping it alive.

## How

One line: the reader loop touches `last_activity` on every event the process emits. "Idle" now means *producing nothing*, which is what the reaper was always meant to collect. A session streaming tool results, subagent events, or text can never be reaped mid-work; a genuinely silent session still gets collected on the normal timeout.

Running verified on Luo Ji's production bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)