### PR TITLE
brief-delivery: deliver exactly once — verify before any resend (chief-of-staff 1.0.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
       "name": "chief-of-staff",
       "source": "./plugins/chief-of-staff",
       "description": "Chief-of-staff workflows for you and your team \u2014 email briefing, action-item tracking, and the operational routines that keep everything moving.",
-      "version": "1.0.3"
+      "version": "1.0.4"
     }
   ]
 }

--- a/plugins/chief-of-staff/.claude-plugin/plugin.json
+++ b/plugins/chief-of-staff/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chief-of-staff",
   "description": "Chief-of-staff workflows for you and your team — email briefing, action-item tracking, and the operational routines that keep everything moving.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/chief-of-staff/skills/briefing/handbook/brief-delivery.md
+++ b/plugins/chief-of-staff/skills/briefing/handbook/brief-delivery.md
@@ -9,6 +9,7 @@ How to format, deliver, and archive the brief — then reset the notepad for the
 3. **Format it** according to the user's delivery preferences (HTML, markdown, Slack message, etc.). Apply the personality — the delivered brief is where the Alfred voice comes through. The notepad is operational; the delivered brief is the polished output.
 4. **Archive it** — save the delivered brief to `~/briefs/{user}/{DATE}.md` (or `.html`, matching the format). Create the directory if it doesn't exist.
 5. **Deliver it** via the user's preferred channel (Slack DM, email, file link, etc.)
+6. **Deliver exactly once.** If a send call errors, times out, or returns ambiguously, do NOT retry blindly — a timeout is not proof of failure. First check the channel for a message posted since the run started (e.g. Slack `conversations_history`); only re-send if nothing actually landed. Blind retries deliver the same brief two or three times, which reads as spam in the one channel the user asked to trust.
 
 ## Brief Preferences
 


### PR DESCRIPTION
## What
Adds an explicit idempotency step to the brief delivery process: if a send call errors, times out, or returns ambiguously, check the channel history for a message posted since run start before re-sending. A timeout is not proof of failure.

## Why
On 2026-07-16, Piyush's daily brief was posted **three times** in his DM (07:29:45, 07:31:35, 07:31:43 — identical text) because the delivery agent retried blindly after an ambiguous send. The delivery gate then counted all three messages as success evidence. This lands in the exact channel he'd asked to keep quiet two days earlier.

Also bumps chief-of-staff to 1.0.4 (both `plugin.json` and `marketplace.json`) so the auto-updater picks it up.

Local mitigation is already live in the per-user brief-preferences files; this PR makes the fix structural for all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)