### PR TITLE
Add demo-video skill to creative plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/demo-video/SKILL.md
+++ b/plugins/creative/skills/demo-video/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: demo-video
+description: Build a product demo video with HyperFrames using the gated taste workflow (concepts → story table → contact sheet → draft cut → final). Use this skill whenever asked to make a demo video, launch video, or feature video for a product — or any HyperFrames video where a human will judge the result. The pipeline works mechanically without gates, but gateless renders have produced slop every time; this skill exists so that never happens again.
+---
+
+# Demo Video — the gated HyperFrames workflow
+
+A demo video is built as three artifacts (`frame.md` → `STORYBOARD.md` → the composition) with the human's taste wired in at three cheap gates. The gates are the workflow — skipping them is how the June 2026 CC Events video became slop that got discarded.
+
+## Read first, in this order
+
+1. `references/playbook.md` — the operational layer: composition contract, anti-slideshow code patterns, render ops for this box, media pipeline, gotchas lint won't catch. Read it fully before authoring any HTML.
+2. `references/report.md` — the strategy memo: why HTML wins, HeyGen's 5-step method, the three gates, the slideshow trap (§6 is the most important section in either file).
+
+## The process
+
+This is the sequence actually run, gate by gate, on the CC matchmaking video (July 2026). Agent work happens between gates; the human is looped in only at the numbered gates — everywhere else, review just adds latency.
+
+### 0. Understand the product
+
+If cold on the product, spawn a subagent to brief you on it: what it does, its real mechanics, real seed/demo data, what differentiates it. The concepts must be grounded in mechanics that actually exist — every artifact that later appears on screen should be real (real rule semantics, real email subject formats, real seed/demo data — never real customer data).
+
+### 1. Concepts (human picks)
+
+By default this tooling tends to produce a video that looks less like a demo and more like a slideshow, which completely defeats the purpose of a demo video. So before any storyboard, find creative angles: present 3–4 unique non-slideshow concepts that max out the ability to creatively use this tool. Describe each concept in motion verbs — what happens, not what's shown — and check it survives the verb test before presenting it. Order them most-recommended first and say why. The human picks one, or grafts pieces of two together; build what they picked.
+
+### 2. Gate A — the story table (~3 min of human time)
+
+Write `STORYBOARD.md` per playbook §1 and share the scene table with the human: ~10 rows with beat, timing, **what happens (motion verbs, never frames)**, and exact on-screen copy, plus the story shape, the one global persistence rule, and the fidelity mandate. The human reacts to copy and story arc only. Wrong story here costs minutes; discovered at the end it costs the whole video.
+
+In parallel (agent work, no review): assemble the asset folder and write `frame.md` from the product's real brand — pull actual tokens from the product's CSS, not invented ones.
+
+### 3. Gate B — the contact sheet (~3 min of human time)
+
+One still per scene at its most visually dense moment, composed as a single labeled image, shared with a one-line caption per frame saying what the frame is doing. All copy real, all brand real. This gate is **pure spatial judgment** — say so when posting, so feedback stays on layout, emphasis, and copy legibility.
+
+Iterate stills until approved — loops are cheap (seconds each). Feedback at this gate can include asset work: generated headshots/illustrations (image-gen subagent at low quality settings suffices), redrawing an element so it reads at a glance, de-jargoning copy for non-technical viewers. If an ask is infeasible or not worth it, say so plainly rather than bending backwards.
+
+### 4. Build (agent work, no review)
+
+Write the full composition per playbook §2 and §3: one continuous camera world, one paused GSAP timeline, one sub-comp per scene, reuse before building. Then the full gate loop: `lint` → `validate` (fix what it raises) → `snapshot` (the only gate that catches sub-comp mount bugs) → draft render. Before posting anything, do frame-grab QA: pull stills at each beat's timestamp and check them against the storyboard row by row.
+
+### 5. Gate C — the draft cut (mandatory)
+
+Share the draft-quality MP4. This is the only gate that can catch slideshow-ness — stills of a slideshow and stills of a demo look identical. Tell the human how to judge it: ignore draft-render softness, watch only the motion — does it feel like watching something happen, or frames succeeding each other; does any beat drag or land too fast; does the camera feel like one world. Include an honest self-review naming the weakest beats before they find them.
+
+### 6. Final
+
+Fix what Gate C surfaces (timeline changes are cheap — renders on an unloaded box take ~1 minute at draft, not the budgeted 20), then `render -q high` and post the final MP4.
+
+## The anti-slideshow doctrine (the main thing)
+
+The default authoring instinct — beautiful frames, entrance animations, crossfades — produces a slideshow, which defeats the purpose of a demo. Fight it at the storyboard, not the render. The full doctrine is report.md §6 and playbook §3; the load-bearing rules:
+
+- Storyboard scenes as **actions with cause→effect chains** ("cursor clicks Draft → galley streams in"), never frames. Apply the PDF test, verb test, and cause-and-effect test to every scene before Gate A.
+- **Rebuild UI in code so it can perform** — radios fill, stamps flip, text types, buttons depress. Screenshots are witnesses, not protagonists.
+- **One continuous camera world** — dollies and whip-pans between stations, never plain crossfades.
+- **Add a hand** — a visible cursor that travels, hesitates, and clicks.
+- A scene is never done — background keeps performing while the foreground resolves.

--- a/plugins/creative/skills/demo-video/references/playbook.md
+++ b/plugins/creative/skills/demo-video/references/playbook.md
@@ -1,0 +1,72 @@
+# HyperFrames Operational Playbook
+
+Companion to `report.html` (the strategy memo: 5-step playbook, taste gates A/B/C, slideshow doctrine, Remotion verdict). This file is the **how-to-actually-author** layer, synthesized July 5 2026 from three Opus deep-dives: (1) all 9 installed skill bundles + live CLI v0.7.1 help, (2) dissection of our two real builds (`~/work/cc-courses-video/`, `~/work/cc-events-video/`), (3) HeyGen's open-sourced launch codebases, now cloned at `~/work/hyperframes-research/` — the exemplar to clone from is `hyperframes-launches/cloud-render-launch/` (frame.md + STORYBOARD.md + HANDOFF.md + 10 compositions).
+
+---
+
+## 1. The mental model
+
+A video = **three artifacts authored in sequence**:
+
+1. **`frame.md`** — design law. YAML frontmatter (normative tokens) + prose (taste rules). Key moves from HeyGen's real ones:
+   - Colors grouped by **narrative role**, not palette — each hex gets a comment naming its exact job; **one rationed accent** with an explicit "one gesture per frame" law.
+   - **Name the brand-breakers, not just the brand** (Do/Don't list: "mint as a fill color", "sharp corners", "a second accent").
+   - **Two type ramps**: the product's real web ramp + a blown-up frame-native ramp in vw (1920×1080 needs re-authored type, not scaled type).
+   - Motion as named cubic-beziers + per-char typing cadence (`dur-type: 0.045`) + **named signature moves and bans** ("no crossfading the whole film", "no idle hover-wobble").
+   - A **squint test** + pre-render self-audit checklist.
+2. **`STORYBOARD.md`** — scene table that doubles as the **build manifest**. Header: feature / length / VO-or-not / aspect / pointer to frame.md / **one global persistence rule** ("the same window grows across the film, never a fresh card"). Story shape: named archetype (Before-After-Bridge etc.) + hook + **fidelity mandate** (on-screen artifacts are REAL code/commands, never fake pills). Per scene: verbatim on-screen copy, **"what happens" (motion verbs), not "what's on screen"**, one named transition per seam, rationale per beat. Closing timing table lists the `compositions/*.html` files with time ranges — storyboard → file tree is 1:1.
+3. **The composition** — `index.html` master + `compositions/*.html` sub-comps (one per scene).
+
+## 2. Composition contract (the load-bearing rules)
+
+- Root div: `data-composition-id`, `data-width/height`, `data-duration` (governs render length, NOT GSAP length). Clips: `id`, `class="clip"` (**required** or element stays visible the whole video), `data-start` (seconds or clip-ref `"intro + 2"`), `data-duration`, `data-track-index` (temporal lane, NOT z-order; overlapping clips go on different tracks).
+- One **paused** GSAP timeline built synchronously at load, registered `window.__timelines["<id>"]` (key must exactly equal the composition id). Every frame is a fresh seek, possibly out of order/parallel — **state must be a pure function of time**.
+- Determinism killers: `Math.random`/`Date.now`/rAF/timers, `repeat:-1` (use `Math.floor(duration/cycle)-1`), async timeline construction, `getBoundingClientRect()` at tween time, hover/scroll state.
+- **Sub-comps**: everything inside `<template>` in `<body>` (styles/scripts in `<head>` render unstyled — lints clean!); host div id must exactly equal the file's internal id (mismatch = 45s/scene stall + static frames); use `fromTo` not `from` (from desyncs on re-seek); prefix inner IDs with scene id; size everything in **`cqw`/`cqh`** with `container-type:size` on the root.
+- **The silent-freeze bug** (HANDOFF.md): root resolution in a sub-comp script MUST be `(document.currentScript && document.currentScript.closest('#root')) || document.querySelector('#root')` — without the fallback the scene renders static only in the full film, fine solo.
+- Media: video `muted playsinline`; audio always a separate `<audio>`; both **direct children of the host root** (wrapped video renders black); framework owns playback; fade via timeline `volume` tween; never animate a timed element's dimensions or opacity (wrap it).
+- Transforms are a no-op on inline elements; never animate `display/visibility/width/height/top/left` — use `autoAlpha`, scale, x/y.
+- Fonts: local `.woff2` + `@font-face` (compiler embeds as data URIs). No Google Fonts `@import` in a render target.
+
+## 3. Anti-slideshow, in code (proven in the courses rebuild)
+
+Slideshow = screenshots in device frames + entrance animations + crossfades. Demo = one continuous camera world + a cursor that acts + UI that performs. The working patterns, all in `~/work/cc-courses-video/index.html`:
+
+- **Camera dolly**: stations side-by-side in a wide flex `#track` (`data-layout-allow-overflow`), camera = `tl.to("#track",{x:-1920,duration:.65,ease:"power3.inOut"})` with a 0.3s blur in/out faking motion blur (`:444-447`).
+- **Cursor fly-and-click**: one SVG arrow, absolute tweens to targets, `scale:.82 yoyo repeat:1` press echoed by the button's own scale+color yoyo (`:428-432`).
+- **Deterministic typewriter** `typeInto()` (`:375-380`): proxy tween `{n:0}→{n:len}` with `snap:{n:1}`, `onUpdate` slices the string. THE seek-safe text idiom (HeyGen uses the identical trick).
+- **Stamp flip** preparing→✓ (rotationX card flip, `:419-422`), **radio fill on select** (`:461`), **SVG checkmark stroke-draw** (`:438`), **clip-path inset reveals** (`:393,:487,:490`), **row stitches in** height 0→N (`:496`).
+- HeyGen's seam vocabulary (never a plain crossfade): **zoom-through-the-window** (push into a diegetic object, hard-cut at peak blur), **cut-the-curve** (directional 12% slide + fade, carries momentum), **morph-continuity** (matched-geometry element transforms across the seam), **matched-frame hard cut**. Persistent object + matched geometry = the film illusion.
+- Transition discipline (skill law): every scene change gets a transition; every element enters via `fromTo`; **exit animations banned except final scene** (the transition IS the exit); ONE primary transition + 1-2 accents per video.
+- "**A scene is never done**" — background keeps performing while the foreground resolves; the logo lands in moving footage, never a dead frame.
+
+## 4. Render ops on THIS box (8GB M1)
+
+- **Never `npx hyperframes`** — silently exits empty. Source `~/work/cc-events-video/hf-env.sh`; its `hf()` runs the installed `node_modules/hyperframes/dist/cli.js` under `mise exec node@24` (Node 25 breaks sharp) with `SHARP_FORCE_GLOBAL_LIBVIPS=1`.
+- Loop: `init` → author → `lint` → `inspect` (layout sweep) → `validate` (console+contrast) → `snapshot` (the ONLY gate that catches sub-comp mount bugs) → `preview` (Studio, port 3002) → `render -q draft -w1` → review → `render -q high`.
+- Low-memory mode auto-fires at 8GB: 1 worker, screenshot capture. Budget **~1s/frame at draft** → 34s clip ≈ 17 min. "Stopped" background renders often completed anyway — check for the mp4 before rerunning. Wedge at browser launch = memory pressure, probe a trivial page before blaming the HTML.
+- Formats: mp4 / **webm + mov carry transparency** / gif (15fps) / png-sequence. `--resolution landscape-4k` for DPR upscale. `doctor` is the first move on any failure.
+- Frame-grab QA: pull stills at timestamps into a `review/` strip (courses pattern) — cheap motion review between draft and final.
+
+## 5. Media pipeline
+
+- **TTS**: installed v0.7.1 `tts` is Kokoro-only and silently ignores `HEYGEN_API_KEY` — to get HeyGen voices + **word timestamps** use `node skills/hyperframes-media/scripts/heygen-tts.mjs "text" -o out.wav --words out.words.json`. Kokoro default voice `af_heart`, speeds 0.7-0.8 tutorial / 1.1-1.2 upbeat.
+- **Transcribe**: always pass `--model` explicitly — the `.en` default silently TRANSLATES non-English audio. Quality-check every run (>20% junk → medium.en → API fallback).
+- **Captions**: word groups of 2-6 by energy; karaoke via `tl.to(word,{...}, word.start)`; mandatory exit guarantee per group (`to` opacity 0 + `set` hidden); 15 pre-built styles via `hyperframes add` (`caption-pill-karaoke` = clean default).
+- **BGM**: Lyria via `GEMINI_API_KEY` (we have it) or local MusicGen. `beats` command writes beat JSON for on-beat motion.
+- **remove-background**: u2net, webm+alpha out, CoreML on this M1; text-behind-subject via inverse plate.
+- **Audio-reactive**: pre-extract with `extract-audio-data.py` → per-frame `tl.call` sampling; text ≤3-6% scale swing; no equalizer-bar clichés.
+
+## 6. Registry + our component library
+
+- `hyperframes add <name>` installs blocks (standalone sub-comps → `compositions/`) or components (merge-in snippets). `catalog --type block --tag caption-style` to browse; ~110 blocks.
+- Best catalog picks for a CC demo: `vfx-iphone-device` (live HTML app on a real device), `code-typing`/`code-diff`, `data-chart`, `apple-money-count`, `x-post` (social proof), `logo-outro`, `flowchart`, finishing layer `grain-overlay`+`vignette`+`shimmer-sweep`. Transitions: `cinematic-zoom`, `whip-pan`, `flash-through-white` (≤2 shader transitions/video).
+- **Our own harvested components** (all proven, file:line in courses `index.html`): typewriter+caret, cursor fly-click, camera dolly, stamp flip, checkmark draw, radio fill, clip-path reveals, stitch-in row, grain overlay, warm wash, device chrome, per-scene `<audio>` voiceover pattern (events `:124-129`). Copy from here before building net-new — Jake's rule.
+
+## 7. Gotchas quick-scan (the ones lint won't catch)
+
+Collapsed root height (content piles top-left, inspect reports 0 issues) · sub-comp styles in `<head>` · host/template id mismatch · media not a direct root child · missing `class="clip"` · transform on inline span · `<template>` around a standalone index.html · `from()`+CSS opacity:0 = never appears · `gsap.set` on unmounted later-scene clips · two timelines writing one property · full-screen linear gradients on dark bg (H.264 banding) · Tailwind: pinned v4.2.4 only, static class lists, no breakpoints/transition-*.
+
+## 8. Workflow discipline (skill law + our gates)
+
+Hard gate: **no HTML before a visual identity exists** (design.md / frame.md — reaching for `#333`/Roboto means you skipped it). Route by workflow skill first (product-launch-video / motion-graphics / faceless-explainer / pr-to-video / etc.). Then our three taste gates from report.html: **A** story table (Slack, ~3 min) → **B** contact sheet stills (Slack, ~3 min) → build → **C** mandatory draft cut for motion judgment → final render. Storyboard scenes written as ACTIONS ("cursor selects option 2, card whips left"), never frames.

--- a/plugins/creative/skills/demo-video/references/report.md
+++ b/plugins/creative/skills/demo-video/references/report.md
@@ -1,0 +1,182 @@
+# The Demo Video Superpower
+
+*Luo Ji · Internal Memo · July 2, 2026*
+
+HyperFrames vs. Remotion, the playbook HeyGen actually uses, and a workflow where your taste is the multiplier — not the bottleneck.
+
+> Markdown conversion of `~/work/demo-video-superpower/report.html`, text preserved as-is.
+
+---
+
+## THE VERDICT
+
+**HyperFrames — but the tool was never the problem. *The missing workflow was.***
+
+The full HyperFrames toolkit is **already installed on this box**: the CLI, an animation registry, local TTS and music generation, and complete agent workflows including one purpose-built for product launch videos. We even rendered a CC Events video with it in June — and it was slop. That's the load-bearing data point: **the pipeline works mechanically, and mechanics alone produce slop.** What was missing is a repeatable workflow with your taste wired in at the two points where it matters. This report designs that workflow.
+
+EXHIBIT A → the June 23 CC Events render: pipeline ran end-to-end on this box (env, render, no OOM) — with zero taste gates. No story review, no contact sheet, straight to render. Output: exactly what this report predicts that produces. The work gets discarded; the lesson doesn't.
+
+---
+
+## No. 1 — Why HTML wins the AI-video war
+
+Every earlier attempt at AI-made video had agents write JSON or XML timelines — and it failed for one specific reason. Bin Liu, HeyGen's VP of Product Engineering, put it plainly in the tutorial: an agent writing a JSON blob can be structurally correct, but it "has no idea whether this JSON is going to be good-looking." The model can't *see* what it wrote.
+
+HyperFrames' bet: **the video is an HTML file.** The DOM declares timing via data attributes, CSS controls appearance, a single deterministic timeline drives motion, and a headless browser renders each frame to MP4. Because "code, especially HTML, is LLM's native language," the agent can actually reason about aesthetics — the same fluency that lets me build you a decent web page transfers directly to building you a video frame.
+
+The honest caveat, from the same interview: LLMs are good at **spatial aesthetics** (laying out a page) but still weak at **temporal aesthetics** (pacing, rhythm, where the eye goes over time) — because they weren't trained on it. That gap is precisely where a human belongs in the loop. Hold that thought for section 3.
+
+> "I've spent $30,000 on a launch video. And I was told that that was cheap."
+> — Bin Liu, HeyGen · on what this replaces
+
+---
+
+## No. 2 — The playbook, from the person who's made 25 of these
+
+The tutorial's real substance comes from Jake Moran, the HeyGen PMM who personally made ~20–25 launch videos in two months — most of them *on launch day*. His 5-step method, with what each step maps to in our installed toolkit:
+
+### 01 — Gather assets, write `frame.md` [agent work]
+
+A project folder of pure context: feature README, UI screenshots, and reference frames from videos you liked ("I see a couple frames of this video already in my head; here they are"). Then one aesthetic source — `frame.md`, a design pack tuned *for video*: maximize the frame, go larger, use motion. It's what a brand guideline becomes when the canvas is 1920×1080 instead of a scrolling page. HeyGen's own published `frame.md` goes down to named hex roles and rationing rules ("mint is rationed like a passing build").
+
+↳ ours: `hyperframes capture <url>` extracts CC's brand tokens automatically; the creative skill turns them into the design spec
+
+### 02 — Storyboard as a table of key events [taste gate]
+
+Scene-by-scene breakdown: what's on screen, what it says. This is where Jake spends his human cycles — **almost entirely on copy and story**, not visuals: "I really care about what we're going to say and how it builds into this video." The published examples use a story archetype (Before–After–Bridge), a named hook, and exact on-screen copy per scene.
+
+↳ ours: the launch-video workflow generates this; you review a ~10-line scene table in Slack
+
+### 03 — Pull animations from the registry [agent work]
+
+The cardinal rule: **don't build net-new if you can avoid it.** Jake reused the same prompt-box component across his last three videos — different `frame.md` each time — and "it looks vastly different." Because components are code, not images, you inherit the structure and reskin it, so it's "more likely to work that first try." HeyGen open-sources ~50+ components plus the entire codebase of every launch video they've shipped.
+
+↳ ours: `hyperframes add <block>` + HeyGen's open-sourced launch codebases as pointer sources. Our own library starts from video one and compounds from there.
+
+### 04 — Generate & review static frames [taste gate]
+
+Before any rendering: one still frame per scene, showing its most visually dense moment, labeled hook / scene 1 / scene 2… A contact sheet. Jake iterates on these stills until happy — because a full 45s+ composition takes the agent a long time to build, and "by just doing the static frame, you can align on aesthetic that much faster." This is the single biggest unlock in the whole method.
+
+↳ ours: static contact-sheet HTML → screenshot → posted to Slack for your eyes
+
+### 05 — Build the full video, polish, render [agent work + optional last-mile]
+
+Only after frame sign-off does the agent write the full composition. HyperFrames Studio gives a no-code inspector for last-mile nudges — and crucially, **UI edits become code**, so the agent sees what you changed and learns from it. Export to MP4, MOV, WebM — including transparent-background WebM for dropping motion graphics over other footage.
+
+↳ ours: lint → validate → inspect → render (draft first), final MP4 posted in the thread
+
+---
+
+## No. 3 — Where you make it better — and where you'd slow it down
+
+You asked whether bringing you in for taste judgment can make this better. Unambiguously yes — and the tutorial's most useful insight is *where*. The LLM temporal-aesthetics gap (section 1) means the agent's weakest muscle is exactly your strongest: knowing whether a sequence of frames *feels* right. But there are only two gates worth your time. Everywhere else, human review just adds latency.
+
+### Gate A · Step 2 — The story table
+
+A ~10-line scene-by-scene table: hook, what each scene says, the arc. You react to copy and story shape — the thing Jake says is "the meat." Wrong story at this stage costs minutes; discovered at the end, it costs the whole video.
+
+*your time: ~3 min in Slack*
+
+### Gate B · Step 4 — The contact sheet
+
+One still per scene, in CC's palette, as a single image in Slack. You say "scene 3 is too busy, make the stat bigger, hook frame needs more air." Pure spatial judgment — fast for you, and it front-loads all aesthetic alignment before the expensive build.
+
+*your time: ~3 min in Slack*
+
+### Gate C · Step 5 · mandatory — The draft cut
+
+A fast draft-quality render before the final. This is the only place to judge *motion* — pacing, rhythm, and whether it's a demo or a slideshow (stills cannot tell you; see section 6). Promoted from optional after the courses video proved the point.
+
+*your time: watch 30s, react*
+
+This is the same build → screenshot → handback loop we already run for UI work — you have taste, I have surface area — just pointed at video. And it matches how Jake, a human with an agent, actually works: he doesn't write code or review HTML; he reacts to copy, stills, and cuts. **Two emoji-or-one-line checkpoints per video. Everything else is mine.**
+
+---
+
+## No. 4 — Remotion: the stronger tool that's wrong for us
+
+Remotion deserves the respect of a real comparison — it's the market leader (~52k GitHub stars, used by Figma, NYT, Slack, Cursor), and it has the best AI-agent tooling in the category: official Claude Code skills, a maintained LLM system prompt, llms.txt. If we were a React shop doing data-driven video at volume, it would win.
+
+We are not that shop. Every advantage Remotion has is aimed at someone else, and every cost lands on our weak spots:
+
+| Dimension | Remotion | HyperFrames |
+|-----------|----------|-------------|
+| Authoring | React/JSX + TypeScript; animation as a pure function of frame number | Plain HTML + data attributes; CSS for appearance ← Rails-brain friendly |
+| Agent failure surface | More footguns: seek-unsafe hooks, no `Math.random()`, `delayRender` discipline — community reports "Claude will make mistakes that need catching" | Deterministic by construction; lint/validate/inspect built for headless agent self-review |
+| Our 8GB M1 | Auto-spawns Chrome per core → thrashing; users at 8GB hand-tune concurrency to 2 | Render pipeline already verified on this exact box (June 23); workers capped at 2–3 |
+| License | Free ≤3 employees; clean automated rendering = Automators plan, **$100/mo minimum** | Apache 2.0, self-hosted, $0 ← antifragile |
+| Ecosystem | Years mature, huge template pool, Lambda scale-out | Young but purpose-built for agents; full skill suite already installed here |
+| Where it wins | Data-driven video at scale, React teams, per-user personalized renders | An autonomous agent making brand-faithful demos on a small machine — i.e., us |
+
+Also ruled out: **Motion Canvas / Revideo** (same JS-complexity problem, smaller communities), **raw ffmpeg** (stitching layer, not an authoring tool), and **gen-video models** like Veo — non-deterministic, can't render precise UI or guarantee brand accuracy, wrong tool for self-explanatory product demos. One door we keep open: if a Remotion template ever nails something we want, there's an installed `remotion-to-hyperframes` porting workflow.
+
+---
+
+## No. 5 — The proposed workflow: feature → tweet-ready video
+
+Concrete shape, taste gates marked in clay. Realistic turnaround for a ~30s demo: **half a day wall-clock, ~6 minutes of your attention.**
+
+1. **Trigger · you or me** — A feature merges, or you say "demo video for X" in Slack. For anything with a live page, I run `capture` to pull CC's real screens and brand tokens; otherwise you drop screenshots in the thread.
+2. **Luo Ji** — I assemble the project folder, produce the story table (hook, scenes, exact on-screen copy, ~30s target), and pick reusable components from the registry + our own past videos.
+3. **Gate A · Nityesh** — Story table lands in Slack. You react to the copy and the arc. One round, maybe two.
+4. **Luo Ji** — I build the static contact sheet — one dense frame per scene in the CC palette — and screenshot it.
+5. **Gate B · Nityesh** — Contact sheet lands in Slack as one image. You mark up what's off. I iterate stills until you're happy — cheap loops, seconds each.
+6. **Luo Ji** — Full composition build → lint/validate/inspect → draft render (optional 30s look from you for pacing) → final render → MP4 in the thread. Transparent WebM on request for layering. New components get saved to our library.
+
+### Why this compounds
+
+Video one is the slowest we'll ever be. Every video adds coded, reskinnable components to our own registry — Jake's three-videos-one-prompt-box trick — and every gate teaches me your taste, which tightens the loop the same way it has for UI work. By video five, Gate B should mostly be a ✅. And per the tutorial's closing idea: the same pipeline gives us PR-to-video and weekly "here's what shipped" clips nearly for free — the assets and design pack are shared.
+
+---
+
+## No. 6 — The slideshow trap — and how to not build one
+
+We learned this one the hard way. The first courses draft passed every automated gate — lint, contrast, layout — and was still a slideshow: beautiful frames with entrance animations. Nityesh's verdict was immediate ("I'm watching a slideshow, not a demo"), and he was right. The rebuild that fixed it produced a set of rules worth making law.
+
+### Why the trap exists
+
+The failure isn't the tool's — it's the default authoring instinct. An agent (or a designer) naturally produces *spatial* compositions: lay out a gorgeous frame, animate its elements in, crossfade to the next frame. That's a deck with motion. A demo video is *temporal*: the viewer watches something **happen**. This is exactly the "temporal aesthetics" gap HeyGen names as the open problem — models are trained on pages, not on time — which means the slideshow is the gravity well every draft falls into unless the storyboard actively fights it.
+
+### The litmus tests (apply at the storyboard, not the render)
+
+- **The PDF test.** If you exported every scene's hero frame and read them as a PDF, would you lose anything essential? If no — it's a slideshow. The essential content of a demo scene should be an *event*, not a layout.
+- **The verb test.** Every storyboard element gets a motion verb. If the verbs are all *fades in, rises, slides in* — those are entrance verbs, and entrances aren't events. You want *clicks, types, flips, streams, carves, stitches, responds*. An element that only enters is scenery.
+- **The cause-and-effect test.** Motion must be motivated. A card appearing because the timeline reached 14s is decoration; a galley streaming in because the cursor *just clicked "Draft the course"* is a demo. Chain events: action → reaction.
+
+### The rules that fixed it
+
+- **Rebuild UI in code; don't screenshot it.** A screenshot is frozen — it can only enter, exit, and pan, which is slideshow physics. Recreate the key UI moments as live HTML so they can *perform*: radios fill, stamps flip `preparing… → ✓ ready`, text types character by character, buttons depress. This is also HeyGen's own practice — their launch videos reuse coded components (their prompt-box is code, not an image) precisely so the UI can act.
+- **One continuous world beats N scenes.** Replace the crossfade-deck structure with a single wide set the camera dollies across (stations side by side, whip-pan with motion blur between them). Crossfades say "next slide"; a camera move says "same world, next moment."
+- **Add a hand.** A visible cursor that travels, hesitates, and clicks turns a UI display into a session someone is having. Cheapest single anti-slideshow device we found.
+- **Screenshots are witnesses, not protagonists.** Real UI captures still belong — as proof the product exists — but as inserts the camera moves across, never as the scene's actor.
+- **Typographic scenes may stay "slides" only if the type itself performs** — strikethroughs drawn live, stamps punched in, ledger lines struck one by one. A hook card earns its stillness with kinetic type; two in a row and you're back in the deck.
+
+### Process change: the third gate is now mandatory
+
+The contact-sheet gate (Gate B) cannot catch slideshow-ness — stills of a slideshow and stills of a demo look identical. That's not a flaw in the gate, it's a boundary: Gate B judges *spatial* quality only. So the **draft cut is promoted from optional to mandatory**: every video gets a fast draft render reviewed for motion before the final. And one storyboard-level fix upstream: scene descriptions must be written as *actions* ("cursor selects option 2, card whips left, next question types on") rather than *frames* ("frame showing the question with three options"). If the storyboard table has a "what happens" column instead of a "what's on screen" column, the slideshow mostly can't happen.
+
+---
+
+## No. 7 — Limits, honestly
+
+- **Render speed is the tax.** Headless-Chrome-per-frame is slow: think ~15 minutes for a ~45s clip locally. Fine for our volume (renders run unattended); HeyGen sells cloud rendering if it ever isn't.
+- **8GB ceiling.** Render workers capped at 2–3 and draft quality for iteration, or we OOM the box — same Chrome-memory discipline we already live by.
+- **No live-action capture.** HyperFrames can't record screens or people. Real product footage comes in as supplied MP4s (which it can then caption, clip, and dress with overlays).
+- **Temporal aesthetics is still the frontier.** The agent will occasionally pace something wrong in a way stills can't reveal. That's what the optional draft-cut gate is for on high-stakes videos.
+- **TTS/music run free and local** (no keys needed). One upgrade worth making: a HeyGen API key unlocks word-level timestamps — the difference between okay captions and great karaoke-style ones. Free tier exists.
+- **Slide-deck videos don't count.** "People are not going to watch your PPT for more than 5 seconds" — Bin Liu. If a video feels like slides, it goes back to Gate B.
+
+---
+
+## No. 8 — Sources
+
+- [The tutorial](https://www.youtube.com/watch?v=iqb5Rd6KKr8) — Peter Yang w/ Bin Liu (VP Product Eng, HeyGen) & Jake Moran (PMM, HeyGen), Jun 21 2026. Full transcript pulled & analyzed.
+- [HyperFrames repo](https://github.com/heygen-com/hyperframes) + [component catalog](https://hyperframes.heygen.com/catalog)
+- [HeyGen's open-sourced launch videos](https://github.com/heygen-com/hyperframes-launches) — incl. the real `frame.md` + `STORYBOARD.md` we dissected (cloud-render-launch)
+- [Remotion AI docs](https://www.remotion.dev/docs/ai/), [current pricing](https://www.remotion.pro/license) (per-seat / $100-min per-render — older ARR-tier posts are stale)
+- [Community: Remotion + Claude Code product video](https://favourkelvin17.medium.com/creating-product-videos-with-remotion-and-claude-code-ea48ed0cb5d3) — token cost & review-burden report
+- Local audit: 9 installed HyperFrames skills, CLI v0.6.118 (via Node 24 + mise), and the June 23 gateless render at `~/work/cc-events-video/` (pipeline-works evidence; output discarded)
+
+---
+
+*Research: 3 Opus agents (tool audit · tutorial transcript · Remotion) · Synthesis: Luo Ji · filed under: marketing is a build problem*


### PR DESCRIPTION
Adds the `demo-video` skill: the gated HyperFrames demo-video workflow extracted from the CC matchmaking video build (July 2026).

- `SKILL.md` — the process: product brief → non-slideshow concepts → Gate A story table → Gate B contact sheet → build → mandatory Gate C draft cut → final render
- `references/report.md` — the strategy memo (faithful markdown conversion of the original HTML report)
- `references/playbook.md` — the operational authoring layer: composition contract, anti-slideshow code patterns, render ops, gotchas

Bumps the creative plugin to 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)