### PR TITLE
Update demo-video skill from first real usage

### DIFF
--- a/plugins/creative/skills/demo-video/SKILL.md
+++ b/plugins/creative/skills/demo-video/SKILL.md
@@ -22,13 +22,15 @@ If cold on the product, spawn a subagent to brief you on it: what it does, its r
 
 ### 1. Concepts (human picks)
 
-By default this tooling tends to produce a video that looks less like a demo and more like a slideshow, which completely defeats the purpose of a demo video. So before any storyboard, find creative angles: present 3–4 unique non-slideshow concepts that max out the ability to creatively use this tool. Describe each concept in motion verbs — what happens, not what's shown — and check it survives the verb test before presenting it. Order them most-recommended first and say why. The human picks one, or grafts pieces of two together; build what they picked.
+By default this tooling tends to produce a video that looks less like a demo and more like a slideshow, which completely defeats the purpose of a demo video. So before any storyboard, find creative angles: present 3–4 unique non-slideshow concepts that max out the ability to creatively use this tool. Describe each concept in motion verbs — what happens, not what's shown — and check it survives the verb test before presenting it. Order them most-recommended first and say why. The human picks one, or combines several — a fused pick makes a longer film, and that's fine when the human wants the full power shown; build what they picked.
 
 ### 2. Gate A — the story table (~3 min of human time)
 
 Write `STORYBOARD.md` per playbook §1 and share the scene table with the human: ~10 rows with beat, timing, **what happens (motion verbs, never frames)**, and exact on-screen copy, plus the story shape, the one global persistence rule, and the fidelity mandate. The human reacts to copy and story arc only. Wrong story here costs minutes; discovered at the end it costs the whole video.
 
-In parallel (agent work, no review): assemble the asset folder and write `frame.md` from the product's real brand — pull actual tokens from the product's CSS, not invented ones.
+Surface the key text frames (the claim/kinetic-type copy) explicitly at this gate — they carry the film's voice, they're where dry humor can live, and the human will want to react to them line by line. And if the human answers with the points they'd make if *they* were explaining the feature, treat that as the find of the gate: those points are the film's text-frame skeleton — state each claim on screen and prove it with the scene that follows.
+
+In parallel (agent work, no review): assemble the asset folder and write `frame.md` from the product's real brand — pull actual tokens from the product's CSS, not invented ones. Pin any reference screenshots the human shares into `assets/` — they are the source of truth for rebuilt UI.
 
 ### 3. Gate B — the contact sheet (~3 min of human time)
 
@@ -36,9 +38,11 @@ One still per scene at its most visually dense moment, composed as a single labe
 
 Iterate stills until approved — loops are cheap (seconds each). Feedback at this gate can include asset work: generated headshots/illustrations (image-gen subagent at low quality settings suffices), redrawing an element so it reads at a glance, de-jargoning copy for non-technical viewers. If an ask is infeasible or not worth it, say so plainly rather than bending backwards.
 
+When frames rebuild a real product's UI — the product being demoed, or a third-party surface like a chat client — approximate-from-memory fails this gate. Build the skins from real sources: the product's actual CSS and view partials, official logo assets, sampled palettes from the human's reference screenshots. If the human flags fidelity issues, the proven fix is a detail pass with the references in hand and a screenshot-compare loop that iterates until clean, forbidden from touching approved copy or beats.
+
 ### 4. Build (agent work, no review)
 
-Write the full composition per playbook §2 and §3: one continuous camera world, one paused GSAP timeline, one sub-comp per scene, reuse before building. Then the full gate loop: `lint` → `validate` (fix what it raises) → `snapshot` (the only gate that catches sub-comp mount bugs) → draft render. Before posting anything, do frame-grab QA: pull stills at each beat's timestamp and check them against the storyboard row by row.
+Write the full composition per playbook §2 and §3: one continuous camera world, one paused GSAP timeline, one sub-comp per scene, reuse before building. The storyboard is law and the approved contact sheet is the visual source of truth — lift its markup directly rather than re-inventing frames. Then the full gate loop: `lint` → `validate` (fix what it raises) → `snapshot` (the only gate that catches sub-comp mount bugs) → draft render. Before posting anything, do frame-grab QA: pull stills at each beat's timestamp and check them against the storyboard row by row. If a subagent did the build, verify its output with your own eyes before sharing — subagent reports are hearsay.
 
 ### 5. Gate C — the draft cut (mandatory)
 
@@ -46,7 +50,9 @@ Share the draft-quality MP4. This is the only gate that can catch slideshow-ness
 
 ### 6. Final
 
-Fix what Gate C surfaces (timeline changes are cheap — renders on an unloaded box take ~1 minute at draft, not the budgeted 20), then `render -q high` and post the final MP4.
+Fix what Gate C surfaces — both the human's notes and the weaknesses you named yourself (timeline changes are cheap; draft renders take a couple of minutes, not the tens you'd budget). Then `render -q high` and share the final MP4.
+
+Audio enters here, after Gate C, so motion gets judged silent first. Sound only what the story sources: BGM as a quiet underscore that fades as the wordmark lands; typing sounds only under text a human types on screen, never under the AI's replies — the AI isn't at a keyboard. Calibrate one gain across all SFX clips, and verify every audio change by measurement (LUFS/RMS windows against the previous cut), not by ear.
 
 ## The anti-slideshow doctrine (the main thing)
 

--- a/plugins/creative/skills/demo-video/references/playbook.md
+++ b/plugins/creative/skills/demo-video/references/playbook.md
@@ -44,7 +44,8 @@ Slideshow = screenshots in device frames + entrance animations + crossfades. Dem
 
 - **Never `npx hyperframes`** — silently exits empty. Source `~/work/cc-events-video/hf-env.sh`; its `hf()` runs the installed `node_modules/hyperframes/dist/cli.js` under `mise exec node@24` (Node 25 breaks sharp) with `SHARP_FORCE_GLOBAL_LIBVIPS=1`.
 - Loop: `init` → author → `lint` → `inspect` (layout sweep) → `validate` (console+contrast) → `snapshot` (the ONLY gate that catches sub-comp mount bugs) → `preview` (Studio, port 3002) → `render -q draft -w1` → review → `render -q high`.
-- Low-memory mode auto-fires at 8GB: 1 worker, screenshot capture. Budget **~1s/frame at draft** → 34s clip ≈ 17 min. "Stopped" background renders often completed anyway — check for the mp4 before rerunning. Wedge at browser launch = memory pressure, probe a trivial page before blaming the HTML.
+- Low-memory mode auto-fires at 8GB: 1 worker, screenshot capture. The ~1s/frame draft budget is worst-case — with streaming encode, real drafts came in far faster twice (a 1,260-frame draft in 71s; a 2,280-frame draft in ~2 min), so iterate freely. "Stopped" background renders often completed anyway — check for the mp4 before rerunning. Wedge at browser launch = memory pressure, probe a trivial page before blaming the HTML.
+- `hf()` cd's into its home project directory, so renders land in THAT project's `renders/`, not yours — go fetch the mp4 from there.
 - Formats: mp4 / **webm + mov carry transparency** / gif (15fps) / png-sequence. `--resolution landscape-4k` for DPR upscale. `doctor` is the first move on any failure.
 - Frame-grab QA: pull stills at timestamps into a `review/` strip (courses pattern) — cheap motion review between draft and final.
 
@@ -53,7 +54,9 @@ Slideshow = screenshots in device frames + entrance animations + crossfades. Dem
 - **TTS**: installed v0.7.1 `tts` is Kokoro-only and silently ignores `HEYGEN_API_KEY` — to get HeyGen voices + **word timestamps** use `node skills/hyperframes-media/scripts/heygen-tts.mjs "text" -o out.wav --words out.words.json`. Kokoro default voice `af_heart`, speeds 0.7-0.8 tutorial / 1.1-1.2 upbeat.
 - **Transcribe**: always pass `--model` explicitly — the `.en` default silently TRANSLATES non-English audio. Quality-check every run (>20% junk → medium.en → API fallback).
 - **Captions**: word groups of 2-6 by energy; karaoke via `tl.to(word,{...}, word.start)`; mandatory exit guarantee per group (`to` opacity 0 + `set` hidden); 15 pre-built styles via `hyperframes add` (`caption-pill-karaoke` = clean default).
-- **BGM**: Lyria via `GEMINI_API_KEY` (we have it) or local MusicGen. `beats` command writes beat JSON for on-beat motion.
+- **BGM**: Lyria via `GEMINI_API_KEY` (we have it) or local MusicGen. `beats` command writes beat JSON for on-beat motion. **No `bgm` CLI command has ever shipped** (verified absent from 0.7.1 through 0.7.99; the hyperframes-media doc describes it anyway) — call Lyria directly via `google-genai` with the same key, and check the generator script into the project so the track is reproducible.
+- **Volume tweens are ignored by the 0.7.1 runtime** (renders a flat bed) — bake fades into the WAV with ffmpeg, keep the unfaded master beside it, and record the exact filter chain in a comment so nobody re-derives it; a tween re-added on a newer runtime would double-apply.
+- **Typing SFX**: clicks only under text a human types on screen, never under AI replies (the AI isn't at a keyboard). One gain calibrated across all clips — per-clip normalization makes the shortest burst the loudest. Verify the mix by measured LUFS/RMS windows against the previous cut, not by ear.
 - **remove-background**: u2net, webm+alpha out, CoreML on this M1; text-behind-subject via inverse plate.
 - **Audio-reactive**: pre-extract with `extract-audio-data.py` → per-frame `tl.call` sampling; text ≤3-6% scale swing; no equalizer-bar clichés.
 


### PR DESCRIPTION
Refinements to the `demo-video` skill based on its first real run (the CC MCP "Connect your AI" video, Aug 2026). Every change traces to something that actually happened in that build — no speculative additions.

**SKILL.md**
- Concepts: the human may combine several concepts, not just two — a fused pick makes a longer film and that's fine.
- Gate A: surface the key text frames for line-by-line review; when the human states the points they'd make pitching the feature themselves, those points become the film's claim skeleton (this restructured the MCP film and made it better).
- Gate A/B: reference screenshots get pinned to `assets/` as source of truth; rebuilt product UI must come from real sources (actual CSS/partials, official logos, sampled palettes) — approximate-from-memory failed Gate B twice, and a screenshot-compare detail pass fixed it.
- Build: the approved contact sheet is the visual source of truth; subagent output gets verified directly before sharing.
- Final: fix self-named weaknesses too, not just the human's notes; audio enters after Gate C (motion judged silent first), typing SFX under human-typed text only, all audio changes verified by measurement.

**references/playbook.md**
- Render budgets corrected from two real builds (drafts land in minutes with streaming encode).
- `hf()` cd gotcha: renders land in the wrapper's home project.
- No `bgm` CLI command has ever shipped — call Lyria directly; 0.7.1 ignores volume tweens — bake fades into the WAV.
- Typing-SFX calibration rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)