### PR TITLE
Escalate a failed stop to SIGKILL so a thread can't go silent

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1722,11 +1722,25 @@ def _interrupt_session(session: LiveSession) -> bool:
         logger.warning(f"Interrupt write failed for {session.thread_ts}: {e}")
     if session._turn_done.wait(timeout=5):
         return True
-    # Interrupt didn't land — hard-kill; the thread resumes via --resume next message
-    try:
-        session.proc.terminate()
-    except Exception:
-        pass
+    # Interrupt didn't land — hard-kill; the thread resumes via --resume next message.
+    # SIGTERM, then SIGKILL: a CLI wedged in a hung tool call ignores SIGTERM, and a
+    # survivor stays in _live_sessions, so every later message in that thread is written
+    # to a stdin nobody reads and the thread goes silent with no error anywhere.
+    proc = session.proc
+    for stop in (proc.terminate, proc.kill):
+        try:
+            stop()
+            proc.wait(timeout=5)
+            break
+        except Exception:
+            pass
+    if proc.poll() is None:
+        logger.error(f"Could not kill pid={proc.pid} for thread {session.thread_ts}")
+    else:
+        logger.info(f"Hard-killed pid={proc.pid} for thread {session.thread_ts}")
+        with _live_sessions_lock:
+            if _live_sessions.get(session.thread_ts) is session:
+                _live_sessions.pop(session.thread_ts, None)
     session._turn_done.set()
     return False
 
@@ -1754,8 +1768,12 @@ def _maybe_stop_from_message(event: dict) -> bool:
 
     def _do_stop():
         clean = _interrupt_session(session)
-        note = ("stopped mid-run — tell me where to go instead" if clean
-                else "had to hard-kill the process; the thread resumes with full context on your next message")
+        if clean:
+            note = "stopped mid-run — tell me where to go instead"
+        elif session.proc.poll() is not None:
+            note = "had to hard-kill the process; the thread resumes with full context on your next message"
+        else:
+            note = "couldn't kill the process — it's wedged and this thread won't answer until it's cleared by hand"
         try:
             slack_client.chat_postMessage(
                 channel=session.channel, thread_ts=session.thread_ts,


### PR DESCRIPTION
## The bug

A Slack thread stopped answering today with no error anywhere — no reply, no new session, nothing in the log.

`stop` in a thread sends the CLI an interrupt, waits 5s, then calls `terminate()` and posts *"had to hard-kill the process"* — without ever checking whether the process died. A CLI wedged in a hung tool call ignores SIGTERM, so it didn't.

From there the failure is silent by construction:

1. The process survives, so `proc.poll()` stays `None`.
2. The reader loop never sees EOF, so it never reaches the `finally` that pops the session from `_live_sessions`.
3. The next message in that thread finds a "live" session and gets written to the stdin of a process that will never read it.

No spawn, no reply, no exception. The only way to notice is a human asking why the bot went quiet.

## The fix

Escalate SIGTERM to SIGKILL, evict the session once the process is confirmed dead, and only claim the kill in Slack when `poll()` proves it. If even SIGKILL somehow leaves it alive, say so instead of claiming a stop that didn't happen.

## Verification

A regression test against the real function, using a child that installs `SIG_IGN` for SIGTERM as the wedged-CLI stand-in:

- **Pre-patch:** `AssertionError: FAIL: pid 59774 survived the stop`
- **Post-patch:** `PASS: SIGTERM-ignoring pid 59604 killed in 10.1s, session evicted, turn unblocked`

10.1s = the 5s interrupt wait plus the 5s SIGTERM grace before SIGKILL.

The test isn't committed — this repo has no test harness, and a lone test file with no runner is decoration.