### PR TITLE
Announce the serving model at the top of a Slack thread

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -518,6 +518,9 @@ class LiveSession:
     pending_reactions: list = field(default_factory=list)
     # Highest 100k context threshold already announced in the thread
     ctx_notified_level: int = 0
+    # Model last announced in the thread (from message.model on assistant
+    # events — the served model, not the --model flag). "" = not yet announced.
+    model_notified: str = ""
     # Messages sent into this process, for the per-model prompt cadence. Resets
     # when the thread's process is respawned after an idle-out.
     turns_sent: int = 0
@@ -726,6 +729,39 @@ def _post_skill_notice(session: LiveSession, skill: str, args_str: str) -> None:
         logger.warning(f"Failed to post skill notice: {e}")
 
 
+def _post_model_notice(session: LiveSession, model: str, prev: str) -> None:
+    """Post a small grey context-block notice naming the serving model.
+
+    `model` comes from message.model on the assistant event — the API's report
+    of which model actually produced the response, so it stays truthful under
+    silent fallbacks (e.g. opus-5 → opus-4-8). Posted once per session and
+    again only if the served model ever changes.
+    """
+    try:
+        note = f"model: {model}" if not prev else f"model changed: {prev} → {model}"
+        slack_client.chat_postMessage(
+            channel=session.channel, thread_ts=session.thread_ts,
+            text=note,
+            blocks=[{"type": "context", "elements": [
+                {"type": "mrkdwn", "text": f":robot_face: _{note}_"}]}],
+        )
+    except Exception as e:
+        logger.warning(f"Failed to post model notice: {e}")
+
+
+def _track_model(session: LiveSession, data: dict) -> None:
+    """Announce the served model on the first main-loop assistant event of a
+    session, and re-announce if it changes mid-thread (fallback routing).
+    Subagent events are skipped — they may run a different model than the
+    thread itself."""
+    if data.get("parent_tool_use_id"):
+        return
+    model = data.get("message", {}).get("model") or ""
+    if model and model != session.model_notified:
+        _post_model_notice(session, model, session.model_notified)
+        session.model_notified = model
+
+
 def _track_context(session: LiveSession, data: dict) -> None:
     """Watch usage on assistant events; announce each new 100k threshold.
 
@@ -779,6 +815,7 @@ def _reader_loop(session: LiveSession) -> None:
                     session.session_id = sid
 
             elif msg_type == "assistant":
+                _track_model(session, data)
                 _track_context(session, data)
                 content = data.get("message", {}).get("content", [])
                 # Subagent (Agent/Task) events stream through the same stdout


### PR DESCRIPTION
A thread gave no indication of which model was answering it.

`model-config.json` sets a *preference*, but the API can silently fall back to a different model — so the config file is not a reliable answer to "what am I actually talking to."

This reads `message.model` off the assistant event instead — the API's own report of what produced the response — and posts it once per session in the same grey context block already used for context and skill notices:

> :robot_face: _model: claude-opus-5_

It re-announces only if the served model changes mid-thread, which is the part that makes a silent fallback visible:

> :robot_face: _model changed: claude-opus-5 → claude-opus-4-8_

Subagent events are skipped — they carry `parent_tool_use_id` and may run a different model than the thread itself. The notice is posted by the bot and never enters Claude's context, matching `_post_context_notice` and `_post_skill_notice`.

## Verification

Running in production on our own instance. Also driven directly against `_track_model` with five real-shaped assistant events:

| event | expected | result |
|---|---|---|
| `claude-opus-5` (first) | announce | `model: claude-opus-5` |
| `claude-opus-5` (repeat) | silent | no post |
| `claude-opus-4-8` | announce change | `model changed: claude-opus-5 → claude-opus-4-8` |
| `claude-haiku-4-5` with `parent_tool_use_id` | skip | no post |
| empty model string | skip | no post |

Five events, two notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)