### PR TITLE
Redact real people and tailnet IPs from the published repo

### DIFF
--- a/misc/file-explorer/server.py
+++ b/misc/file-explorer/server.py
@@ -49,13 +49,12 @@ DISPLAY_NAME = os.environ.get("FILE_EXPLORER_NAME", "Your AI Employee")
 # seeing the "unknown visitor" view, ask them to run `tailscale ip -4` on their
 # machine and add the IP here. On macOS App Store Tailscale, the IP is visible
 # in the Tailscale menu bar icon under "This machine."
+# Replace every entry below with your own tailnet's IPs — the defaults are
+# placeholders and match nobody.
 TAILSCALE_USERS = {
-    "100.123.10.100": {"name": "Claudie", "ring": 0},   # this machine (self)
-    "100.71.120.89":  {"name": "Nityesh", "ring": 1},
-    # Add more team members here as they connect:
-    # "100.x.x.x": {"name": "Natalia", "ring": 1},
-    # "100.x.x.x": {"name": "Mike", "ring": 2},
-    # "100.x.x.x": {"name": "Brooker", "ring": 2},
+    # "100.x.x.x": {"name": "This machine", "ring": 0},
+    # "100.x.x.x": {"name": "Supervisor",   "ring": 1},
+    # "100.x.x.x": {"name": "Teammate",     "ring": 2},
 }
 
 # Paths restricted by ring. Ring N can see everything rings > N cannot.

--- a/plugins/creative/skills/create-zine-comic/references/ref-architecture-infographic.md
+++ b/plugins/creative/skills/create-zine-comic/references/ref-architecture-infographic.md
@@ -106,7 +106,7 @@ Clean panel, warm background. Practical guidance framed as a decision tree:
 
 "When you tell me something important, ask yourself:"
 
-- **"Must Claudie NEVER forget this?"** → Tell Nityesh or Natalia to add it to CLAUDE.md
+- **"Must Claudie NEVER forget this?"** → Tell one of your humans to add it to CLAUDE.md
 - **"Is it specific to a project?"** → It belongs in that project's folder CLAUDE.md
 - **"Is it about how to do a task?"** → It should be a skill
 - **"Is it a preference or correction?"** → I'll save it as a memory

--- a/plugins/creative/skills/creative-lead/examples/creative-direction-file-explorer.md
+++ b/plugins/creative/skills/creative-lead/examples/creative-direction-file-explorer.md
@@ -1,7 +1,7 @@
 # Creative Direction: Luo Ji's File Explorer
 
 **Product:** A web-based file browser that lets two humans look inside the mind of their AI cofounder
-**Runs on:** A MacBook Air M1 in Kolkata, served via Tailscale at http://100.89.76.77:8888
+**Runs on:** A spare MacBook, served over Tailscale at `http://<your-tailnet-host>:8888`
 
 ---
 
@@ -206,7 +206,7 @@ Minimal. This is not a glassmorphism exercise.
 
 ### The Diary Folder (Special Treatment)
 
-The diary deserves a moment of design attention beyond what other directories get. When you navigate to `/browse/Users/luo/diary`, the listing should feel different — not through a different layout, but through one small detail: instead of showing just the filename (2026-03-30.md), show the date formatted as a readable date with the day of the week: "Sunday, March 30, 2026." This tiny formatting choice transforms a directory listing of YYYY-MM-DD.md files into something that reads like a list of days — a calendar, a logbook, a life being recorded.
+The diary deserves a moment of design attention beyond what other directories get. When you navigate to the diary directory, the listing should feel different — not through a different layout, but through one small detail: instead of showing just the filename (2026-03-30.md), show the date formatted as a readable date with the day of the week: "Sunday, March 30, 2026." This tiny formatting choice transforms a directory listing of YYYY-MM-DD.md files into something that reads like a list of days — a calendar, a logbook, a life being recorded.
 
 This is the memorable detail. A directory listing that looks like a diary's table of contents. It costs nothing to implement and it reframes the entire experience.
 


### PR DESCRIPTION
The public repo names real people who did not agree to be in it.

`misc/file-explorer/server.py` shipped two real Tailscale IPs mapped to real names, plus three more colleagues named in commented-out entries. Two plugin docs carried a third IP and another name.

## The second problem

Emptying `TAILSCALE_USERS` also closes a fail-open default.

Tailscale assigns `100.64.0.0/10` addresses **per-tailnet**, so those literals are not unique to us. A fresh installer whose own tailnet happened to hand out `100.71.120.89` silently granted that device ring 1 — and `is_path_allowed` returns `True` unconditionally for `ring <= 1`, so that means full access to memory, session logs, and config, with nothing configured.

With the map empty every visitor falls through to `{"name": "Visitor", "ring": 99}` and gets the restricted view until an operator adds their own IP deliberately. Fail-closed is the correct default for a repo strangers clone.

## What this does not fix

Only the current tree. The IPs and names stay in git history — scrubbing those needs a force-push that breaks every existing clone and fork. Worth doing only if you think the exposure warrants it; the IPs are CGNAT and unroutable from the internet, so the live concern is the names, not the addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)