### PR TITLE
Add explorable-explanation-creator to the creative plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     {
       "name": "more-ai",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ plugins/
 ├── creative/           # Creative direction, writing, brainstorming
 │   └── skills/
 │       ├── creative-lead/    # Creative direction for any project
+│       ├── explorable-explanation-creator/  # Topic → tree of no-scroll interactive HTML pages
 │       ├── lets-brainstorm/  # Timed coaching sessions
 │       ├── help-me-write/    # Collaborative writing (keeps your voice)
 │       └── interview-me/     # Timed discovery interviews

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanation-creator/SKILL.md
+++ b/plugins/creative/skills/explorable-explanation-creator/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: explorable-explanation-creator
+description: Turn any topic, document, analysis, or body of research into an Explorable Explanation — a tree of linked, no-scroll HTML pages where each page is the 80/20 of everything beneath it, the reader clicks into whatever they're curious about, and interactive JavaScript (sliders, simulations, toggles) or visuals carries the ideas prose can't. Use this whenever someone asks for an explorable explanation, an interactive or visual explainer, a multi-page HTML explainer, or to "help me really understand X" — and whenever you'd otherwise reach for a single dense one-page HTML explainer, because this is the next version of that.
+---
+
+# Explorable Explanation Creator
+
+A one-page HTML explainer is a big step up from markdown. Its weakness is that it is one page: everything the topic has to say, stacked, and the reader scrolls through all of it whether they care or not. An Explorable Explanation splits that into a tree. The front page is the whole idea at its lowest resolution; every click zooms into one part at higher resolution; the reader spends attention only on the branches they choose. Bret Victor and Nicky Case hand-built pages like this over weeks — we generate them in a session, so the scarce resource is no longer the code, it's the direction. That's where this skill spends its effort.
+
+## What a good page is — four principles
+
+1. **One idea at one resolution: say it fully at this zoom, draw it so it sticks, and let the doors carry everything finer.**
+2. **A page is done when a reader who stops here leaves knowing the one thing, and a reader who's curious knows exactly where to click.**
+3. **The visual carries the idea; the words carry what the visual can't; the doors carry the rest. Nothing on the page does two jobs.**
+4. **Every sentence earns its place by saying what the visual can't. Every door earns its place by promising more, not hiding the point.**
+
+These are the whole standard. A page that is crammed has words doing the visual's job; a page that is thin has the doors doing the page's job. The fix for the first is never a smaller font or a second column — it's splitting, or cutting the sentence the visual already says. The fix for the second is saying more at this zoom, not adding a door.
+
+## The format — rules the principles don't already cover
+
+- **One screen, no scroll, responsive.** Pages are designed responsively and must hold the no-scroll rule at 1366×700 — a browser window on a 13-inch laptop, MacBook Air or regular — as the floor, while using larger windows gracefully and stacking cleanly on a phone. That floor is the size it must definitely work at, not the only size it's built for. The constraint is what forces the resolution; a page that needs to scroll is two pages.
+- **The visual sets the height; the prose fits beside it.** The prose column is never taller than the visual. If it is, cut the sentences the visual already says — never shrink the font or add a column.
+- **It's a tree, not a menu.** The front page states the crux and offers the first fork. Pages offer one to three doors; children fork again; stop splitting when a page has nothing left a reader would click on. The one sanctioned wide fan is a page whose visual *is* a collection (a map whose regions are doors, a table whose rows are doors).
+- **Doors are words, not addresses.** A door's label is the thing the reader is curious about — *components*, *the phones*, *this had a bill* — never a section number or a title-cased heading. The chrome (breadcrumb, map) carries the address; the body never does. The better door sits inside the visual — the slice, the box, the stage the next page explains — but if you'd have to add words to the picture to make a door, the door belongs in the prose.
+- **An idea with a parameter gets a mechanic.** A diagram where a diagram will do; a slider, toggle, or step-through where the reader learns more by playing. The default state already explains the page — interaction deepens, never unlocks. Start from `references/mechanics.md` — it's inspiration, not a menu.
+- **The theme comes from what the topic literally is.** Every core concept gets an exact counterpart, the theme lives in the chrome, the prose stays plain. If your first theme would fit any topic, it fits this one weakly.
+- **The reader always knows where they are:** breadcrumb and depth always visible; the tree map is **on demand only** — a button or a key opens it, it never sits on the page as a permanent sidebar.
+- **Stick figures are fun.**
+
+## The process — plan, one gate, build
+
+### 1. Ground
+
+Pin three things before designing anything:
+
+- **The reader** — one paragraph: who they are, what they want, the tone that fits, and what they should be able to do afterwards. Then a short list of **terms they already know and don't know**. This list is not meant to be exhaustive but rather a guide. It's what turns reading level from a vibe into something a reviewer can check; without it, builders calibrate to whoever they imagine, and they imagine someone more fluent than the real reader.
+- **The source material** — optional. If the human hands you files, every number and quote traces to them and builders may not invent facts except if something is generally true in the world.
+
+### 2. Plan — the creative phase
+
+This is where the creative energy goes, because a wrong call here is paid on every page downstream while generation is nearly free. Write `plan.md` using `references/plan-template.md`: the tree as an ASCII diagram with a one-line purpose per page, the theme and its metaphor map, the reader and their vocabulary, and for every page its visual or mechanic and its doors. Generate and reject options before committing — the first tree is usually a hub wearing a tree's costume, and the first theme is usually generic.
+
+Then **build the front page for real** — `theme.css`, `nav.js`, `index.html` — and screenshot it. Theme is pure taste, and taste doesn't transfer through a description. The front page is also the exemplar every builder copies, so look at it harder than any other page: a flaw here ships N times. Check it against the doors-are-words rule in particular.
+
+Before presenting, run **the reader's Chad on the plan**: a fresh agent given *only* the reader paragraph and vocabulary list, who reads the purpose sentences cold and flags everything they find complicated. Fix the plan. This costs one agent and catches at the gate what would otherwise surface on 22 built pages.
+
+### 3. The gate
+
+Share `plan.md` and the front-page screenshot together, with your recommended choices and why. Hold here until the human signs off. Edits at this gate cost minutes; the same edits after the build cost a rebuild. If they say stop, stop — never build past the gate on momentum.
+
+### 4. Build — the workflow
+
+On approval, run the bundled workflow. Each builder owns its page's prose column the same way it owns the visual: page-local styles within the theme's tokens, and variation that is semantic — a side-note because it's an aside, a pulled line because it's the one to remember, a term box because a word needs pinning. The theme decides palette, type and spacing; the builder decides how this page's words are set. For every page it runs a builder, then two independent reviews — a **spec checker** (does the page do what plan.md says, in a real browser) and **the Chad reader** (given only the persona and vocabulary, reading cold: can I repeat the idea back, could I point at the picture to do it, do I know where to click, which words would I have to look up, is it too long). A fixer addresses both. Then one crawl of the whole tree for dead doors, orphans and overflow, and one **Chad walk in reading order** for what single pages can't show: the same term glossed five ways, a page that assumes a sibling, a branch that repeats its parent.
+
+```
+Workflow({
+  scriptPath: "${CLAUDE_PLUGIN_ROOT}/workflows/explorable-build.js",
+  args: { dir: "<absolute path to the explorable's folder, containing plan.md, index.html, theme.css, nav.js>" }
+})
+```
+
+#### Who is Chad:
+
+Chad is the artifact's intended audience wearing the meme personality: he meets it cold, with a job to do, and asks dumb questions out loud without a flicker of shame — because looking dumb costs nothing and getting to the point is everything. The other guy performs intelligence and stays paralysed; Chad just says "wait, what does this word mean?" and wins. He is impossible to impress: a nice metaphor, a careful caveat, a clever turn — none of it lands if it doesn't move his job forward. He never pretends to understand something to look smart, and he doesn't do taste debates ("it adds context" — he's the one it's for, and it didn't). He reviews every part and piece, points at the exact words or element he means, and his last comment is always a bird's-eye view of the whole thing: too long, too busy, wrong shape, or does it land. He doesn't rewrite; he comments.
+
+Here Chad's one piece of context is the reader paragraph and the words-they-know list from `plan.md`. Chad *is* that reader. The fixer treats him as an asset, not an opponent: a bullshit detector running before the real reader does, where every comment is a free preview of where a page fails the person it's for. If it works for Chad, it'll probably work for anyone.
+
+### 5. Deliver
+
+Share the link to `index.html` with what shipped (page count, depth), what the checks and Chad caught and fixed, and honest footnotes — any page still over budget, any place the explanation runs on knowledge rather than sources, anything Chad flagged that you chose to keep. The human trusts the artifact because the process shows its receipts.

--- a/plugins/creative/skills/explorable-explanation-creator/references/mechanics.md
+++ b/plugins/creative/skills/explorable-explanation-creator/references/mechanics.md
@@ -1,0 +1,41 @@
+# Mechanics — the interactive vocabulary
+
+An explorable mechanic is a small piece of JavaScript that lets the reader *do* something to an idea and watch it respond. It earns its place on a page when the idea has a parameter — something that varies, and whose variation is the point. A mechanic that decorates rather than teaches is noise; a diagram would have been better.
+
+Three rules that hold for every mechanic:
+
+- **The default state already explains the page.** A reader who never touches anything still gets the 80/20. Interaction deepens; it never unlocks.
+- **One mechanic per page, usually.** Two competing interactions on one screen split attention. If a page wants two, it probably wants to be two pages.
+- **Vanilla JS, inline or in one shared `nav.js`, no build step, no CDN.** The folder must open from disk, offline, years from now. SVG and Canvas are both fine; prefer SVG when parts need to be doors.
+
+Touch and keyboard must both work (sliders: `<input type=range>` gets this free; custom drag handlers need pointer events).
+
+## For inspiration, not a menu
+
+This list is a starting point, not a catalogue to pick from. Use it two ways: take an item straight when it fits, or read it to broaden your sense of what a page can do and invent something the list doesn't have. A mechanic nobody has built before is allowed; a page that picked #4 because #4 was on the list is not the point.
+
+| # | Mechanic | Use when | Gist |
+|---|---|---|---|
+| 1 | **Slider-driven diagram** | One quantity drives a shape, a curve, a count | `<input type=range>` → redraw SVG on `input`; label shows the live value |
+| 2 | **Draggable number in prose** (Tangle-style) | A sentence contains a number the reader should question | `<span class=tangle>` scrubbed by pointer drag; dependent numbers in the paragraph recompute |
+| 3 | **Step-through simulation** | A process unfolds in steps and the order is the lesson | Play / pause / step buttons; state rendered each tick; a scrubber to jump |
+| 4 | **Toggle comparison** | Two states of the same thing: before/after, with/without, A/B | A single switch swaps both the visual and the one-line caption |
+| 5 | **Guess-then-reveal** | The reader has an intuition and it's probably wrong | Reader sets a guess (slider, click on a chart); reveal overlays the truth; the gap is the lesson |
+| 6 | **Build-up sequence** | A diagram is only clear if assembled layer by layer | "Next" adds one layer; each layer gets its caption; last state is the full diagram |
+| 7 | **Hover-to-annotate** | A dense diagram needs labels but labels would clutter it | Hovering (or tapping) a part shows its note; nothing moves |
+| 8 | **Clickable regions as doors** | The visual is a map of the layer below | SVG groups with `<a href>`; hover affordance identical to text links |
+| 9 | **Live sandbox** | The idea is an input→output transform (a regex, a formula, a prompt) | A small editable input; output recomputes on every keystroke; a few preset examples |
+| 10 | **Scrub timeline** | Something changes over time and the shape of the change matters | Drag across a time axis; the visual re-renders for that moment |
+| 11 | **Counterfactual knob** | "What if X were different?" is the real question | A control for X with a clearly marked "actual" position; the visual answers |
+| 12 | **Sortable / filterable catalog** | A wide fan whose rows are doors | Table with column-sort and one filter; every row a link |
+| 13 | **3D scene** (three.js, vendored) | The idea is spatial or structural — a molecule, an architecture, a network, three dimensions of data | Orbit/zoom a scene whose default camera angle already explains it; hover or click parts for labels or doors. Ship `three.min.js` inside the folder so the no-network rule still holds; this is the heavy option, so the page must earn it |
+
+Combine freely but not carelessly: a slider whose diagram's parts are also doors (1 + 8) is the format's signature move — the control teaches this layer, the parts lead to the next. Stick figures are fun.
+
+## Choosing
+
+Read the page's purpose sentence from `plan.md` and ask: *what would the reader most want to poke at here?* If the answer is "nothing, they want to see the shape of it" → a diagram, no mechanic. If the answer names a quantity → 1, 2, 10, 11. A process → 3, 6. A belief → 5. A comparison → 4. A collection → 8, 12. Something spatial → 13. Something none of these fit → invent it, and hold it to the same three rules above.
+
+## Quality bar
+
+Before a builder calls a mechanic done, it drives it in a real browser: the control moves, the visual responds, the default state reads correctly with the page fresh, and nothing pushes the page past one viewport at 1366×700, and the prose beside it is no taller than it.

--- a/plugins/creative/skills/explorable-explanation-creator/references/plan-template.md
+++ b/plugins/creative/skills/explorable-explanation-creator/references/plan-template.md
@@ -1,0 +1,78 @@
+# plan.md — template
+
+`plan.md` is the sign-off surface and the builders' law: nothing built may contradict it. Fill every section; delete the guidance in brackets.
+
+---
+
+# <Title of the explorable>
+
+## Reader
+
+[One paragraph. Who they are, what they want, the tone that fits (ELI5 / curious generalist / practitioner new to this subfield / expert), and what they should be able to do after. Write it like a tutor describing the one student in front of them.]
+
+**Terms they already know / don't know:** [two short lists — a guide, not exhaustive. e.g. for a home cook learning fermentation: knows *yeast, proofing, pH*; doesn't know *lactobacillus, osmotic pressure, brine ratio*. Builders gloss what's on the don't-know side and anything like it; Chad enforces. If the reader is the human asking, confirm with them.]
+
+## Sources
+
+[Either the list of files every fact traces to — or the sentence "No source files; explained from general knowledge," so the human knows which footing this stands on.]
+
+## Tree
+
+[ASCII diagram. Every page, one line of purpose each. Mark doors (→) and cross-links (⇢). Then: node count, max depth.]
+
+```
+index — <the crux in one line>
+├── 01-<slug> — <purpose>
+│   ├── 01a-<slug> — <purpose>
+│   └── 01b-<slug> — <purpose>  ⇢ 02a
+├── 02-<slug> — <purpose>
+│   └── 02a-<slug> — <purpose>
+└── 03-<slug> — <purpose> (catalog: table rows are doors)
+    ├── …
+```
+
+Nodes: N · Depth: D
+
+[Check before presenting: does the front page state a crux and offer a fork, or is it a table of contents? Does any non-catalog page have more than three doors? Does most depth live in one wide fan? Any yes → refactor.]
+
+## Theme
+
+**What the topic literally is:** [the real-world thing this topic already is — the theme plays that completely straight]
+
+**Look:** [palette, type, texture, motion — in a few lines; the rendered index.html is the real spec]
+
+**Metaphor map** — every core concept gets an exact counterpart:
+
+| Concept | In the theme's world |
+|---|---|
+| | |
+
+**Branch identity:** [how a reader knows which limb they're in — e.g. one accent color per top-level branch]
+
+## Navigation
+
+Breadcrumb · depth indicator · tree map with "you are here" · one consistent hover affordance so what's clickable is never a guess. [Describe how these look in this theme.]
+
+## Pages
+
+[One block per page, including index. This is what each builder receives.]
+
+### `<file>.html` — <title>
+- **Purpose:** [the 80/20 of this subtree in one sentence]
+- **Reading level note:** [only if it differs from the reader paragraph]
+- **Visual / mechanic:** [name the mechanic from mechanics.md, or describe the diagram; what the default state shows, what interaction adds]
+- **Doors:** [→ file — the element that is the door (slice, box, row, word). Label = the words the reader is curious about, never a section number or title]
+- **Cross-links:** [⇢ file — if any]
+- **Facts to carry:** [numbers, quotes, claims this page must state, with source file if sourced]
+
+## Writing style
+
+Crux first. Plain prose; one-line gloss on any term of art. Numbers never paraphrased. Theme in the chrome, not the sentences. [Add anything specific to this reader.]
+
+## Delight
+
+[Two or three dry, quiet easter eggs. Optional.]
+
+## Build notes
+
+Shared assets: `theme.css`, `nav.js` (builders copy the index's structure and never edit these). Budget: responsive; must fit a 1366×700 viewport (a browser window on a 13-inch laptop) without scroll as the floor, and the prose column is no taller than the visual. Larger windows get used gracefully, not letterboxed. Mobile: single column, nothing important hidden. Tree map opens on demand (button or key), never a permanent sidebar. Vanilla JS only, no build step, no network dependencies.

--- a/plugins/creative/workflows/explorable-build.js
+++ b/plugins/creative/workflows/explorable-build.js
@@ -1,0 +1,227 @@
+export const meta = {
+  name: 'explorable-build',
+  description: "Build an Explorable Explanation from an approved plan.md: one builder per page copying the index exemplar; per page, a spec check in a real browser plus the reader's Chad reading cold (persona only); a fixer for both; then a whole-tree crawl (dead doors, orphans, overflow) and a Chad walk in reading order, with fixes applied.",
+  whenToUse: 'After the human has approved plan.md and the rendered front page of an explorable explanation. Never before the gate.',
+  phases: [
+    { title: 'Read plan', detail: 'extract the page list from plan.md' },
+    { title: 'Build', detail: 'one builder per page, in parallel' },
+    { title: 'Check', detail: "each page: spec check in a browser + the reader's Chad, cold; then fixes" },
+    { title: 'Crawl', detail: 'whole-tree link + overflow crawl, Chad walk in reading order, then fixes' },
+  ],
+}
+
+// args: { dir } — absolute path to the folder holding plan.md, index.html, theme.css, nav.js
+const A = (args && typeof args === 'object') ? args : { dir: String(args || '').trim() }
+const DIR = A.dir
+if (!DIR) throw new Error('args.dir (the explorable folder) is required')
+
+const PAGES_SCHEMA = {
+  type: 'object', required: ['pages', 'viewport', 'persona', 'knownWords'],
+  properties: {
+    viewport: { type: 'string' },
+    persona: { type: 'string' },     // the Reader paragraph, verbatim
+    knownWords: { type: 'array', items: { type: 'string' } }, // terms allowed unglossed
+    pages: { type: 'array', items: { type: 'object', required: ['file', 'title', 'spec'], properties: {
+      file: { type: 'string' },      // e.g. 02a-judge-model.html
+      title: { type: 'string' },
+      parent: { type: 'string' },    // file of the parent page; empty for index
+      depth: { type: 'integer' },
+      spec: { type: 'string' },      // the page's full block from plan.md, verbatim
+      doors: { type: 'array', items: { type: 'string' } },
+    } } },
+  },
+}
+
+const CHECK_SCHEMA = {
+  type: 'object', required: ['pass', 'findings'],
+  properties: { pass: { type: 'boolean' }, findings: { type: 'array', items: { type: 'string' } }, screenshot: { type: 'string' } },
+}
+
+const CHAD_SCHEMA = {
+  type: 'object', required: ['pass', 'comments'],
+  properties: { pass: { type: 'boolean' }, comments: { type: 'array', items: { type: 'string' } } },
+}
+
+const CRAWL_SCHEMA = {
+  type: 'object', required: ['deadLinks', 'orphans', 'overflow', 'navIssues'],
+  properties: {
+    deadLinks: { type: 'array', items: { type: 'string' } },   // "from.html -> missing.html"
+    orphans: { type: 'array', items: { type: 'string' } },     // files no page links to
+    overflow: { type: 'array', items: { type: 'string' } },    // "file.html: 1120px at 1366x700"
+    navIssues: { type: 'array', items: { type: 'string' } },   // breadcrumb / map / depth wrong
+  },
+}
+
+const GROUND = `The explorable lives at ${DIR}. Read ${DIR}/plan.md first — it is law; nothing you build may contradict it. The format: every page is the 80/20 of its subtree, is responsive and holds no-scroll at the floor viewport (default 1366x700; plan.md's Build notes may override) while using larger windows gracefully, its prose column is no taller than its visual, has at least one visual, offers 1-3 doors (links) to child pages, and carries breadcrumb + depth navigation with the tree map on demand only. Shared assets are ${DIR}/theme.css and ${DIR}/nav.js — use them, never edit them. ${DIR}/index.html is the human-approved exemplar: copy its structure, chrome and navigation pattern exactly.`
+
+phase('Read plan')
+const plan = await agent(`${GROUND}
+
+Extract every page from plan.md's "Pages" section (including index.html) as structured data. For each page return its filename, title, parent filename, depth (index = 0), its full spec block verbatim, and the list of door target filenames. Also return the viewport from Build notes (default "1366x700"), the Reader paragraph verbatim as persona, and the "Words they already know" list as knownWords (empty list if the plan has none). Return only the data.`,
+  { label: 'read plan.md', phase: 'Read plan', schema: PAGES_SCHEMA })
+
+const pages = (plan?.pages || []).filter(p => p.file && p.file !== 'index.html')
+const VIEWPORT = plan?.viewport || '1366x700'
+const PERSONA = plan?.persona || '(no reader paragraph found in plan.md)'
+const KNOWN = (plan?.knownWords || []).join(', ') || '(none listed — gloss every term of art)'
+
+// The reader's Chad. Deliberately cold: persona + vocabulary and nothing else — no spec, no builder report —
+// because a reviewer who has seen the spec reads as the builder, not the reader.
+const CHAD = `You are the reader this explainer was made for. This is you:
+${PERSONA}
+Words you already know and don't need explained: ${KNOWN}. Anything else is a word you'd have to look up.
+You are Chad from the memes: you ask the dumb honest question out loud without a flicker of shame, because looking dumb costs you nothing and getting to the point is everything. You are impossible to impress — a nice metaphor, a careful caveat, a clever turn: none of it lands if it doesn't move your understanding forward. You never pretend to understand something to look smart. You don't do taste debates ("it adds context" — you're the one it's for, and it didn't). You don't rewrite; you comment, pointing at the exact words or element you mean.`
+
+const CHAD_TESTS = `Answer, for this page, as yourself:
+1. Can I repeat the one idea back in my own words after one read? (If not, quote what lost you.)
+2. Could I point at the picture to do it — does the visual carry the idea, or is it decoration next to a wall of text?
+3. Do I know where to click next, and does each door tell me what I'd learn rather than give me a number or a heading?
+4. Which words would I have to look up? List every one.
+5. Is it too long for one screen's worth of attention — are the words saying what the picture already says?
+Return pass=true only if all five are fine. Otherwise one comment per problem, quoting the exact text or element.`
+log(`${pages.length} pages to build (plus the approved index)`)
+
+const buildPrompt = p => `${GROUND}
+
+Build ${DIR}/${p.file} — "${p.title}" (depth ${p.depth}, parent ${p.parent || 'index.html'}).
+
+Its spec from plan.md:
+${p.spec}
+
+Rules for this page:
+- Purpose sentence first; the page is complete at this resolution even if the reader never clicks on.
+- The visual or mechanic named in the spec, built as specified. For a mechanic: the default state already explains the page (interaction deepens, never unlocks); vanilla JS inline; touch + keyboard both work; no CDN or network dependency.
+- Doors exactly as specified (${(p.doors || []).join(', ') || 'none'}), placed on the element the spec names — inside the visual when the spec says so. Same hover affordance as index.html.
+- Breadcrumb, depth indicator and tree-map per index.html, with this page marked as "you are here".
+- Only facts listed in the spec's "Facts to carry" or present in the source files plan.md names. If there are no source files, keep claims general and don't invent numbers.
+- Responsive: no scroll at ${VIEWPORT} (the floor — it must definitely work here, but design for a range, not this one size), uses a wider window gracefully, and the prose column's rendered height is no greater than the visual's; on a 390px-wide phone nothing important is hidden.
+- The prose column is yours to design, the same way the visual is: page-local styles within theme.css's tokens (palette, type, spacing). Vary the setting only where the meaning asks for it — a side-note because it's an aside, a pulled line because it's the one to remember, a term box because a word needs pinning. Never decorative variation, never a new palette or typeface.
+
+Then open the page in a real browser (use whatever browser automation is available to you — a headless Chromium via Playwright is fine), at ${VIEWPORT}: confirm document height <= viewport height, every door resolves to an existing file or one listed in the plan, and the mechanic (if any) responds to input. Fix what you find. Return a 3-line report: what the visual/mechanic is, measured page height at ${VIEWPORT}, anything you could not satisfy.`
+
+const checkPrompt = (p, buildReport) => `${GROUND}
+
+Check ${DIR}/${p.file} against its spec. The builder reported:
+${buildReport}
+
+Builder reports are hearsay; verify with your own eyes. Open the page in a real browser at ${VIEWPORT} and take a screenshot (save it as ${DIR}/.qa/${p.file.replace(/\.html$/, '')}.png). Then judge:
+1. No scroll at ${VIEWPORT} — measure document.documentElement.scrollHeight vs window.innerHeight. And the prose column is no taller than the visual — measure both elements' getBoundingClientRect().height; prose > visual is a fail.
+2. The spec's visual or mechanic is present and, if interactive, responds when driven.
+3. Doors: every link in the spec exists on the page and points to the right file; no doors the spec didn't ask for.
+4. Navigation chrome matches index.html: breadcrumb, depth, tree-map with this page highlighted.
+5. Reading the page cold as the reader described in plan.md: does it deliver the spec's purpose sentence on its own?
+6. Theme consistency with index.html.
+
+Spec:
+${p.spec}
+
+Return pass=true only if all six hold. Otherwise list each concrete finding (what, where, how to fix).`
+
+const chadPagePrompt = p => `${CHAD}
+
+Open ${DIR}/${p.file} in a real browser at ${VIEWPORT} and read it cold, the way you'd land on it from a link. Try the controls if there are any. ${CHAD_TESTS}`
+
+const fixPrompt = (p, findings, chadComments) => `${GROUND}
+
+Fix ${DIR}/${p.file}. Two reviewers looked at it.
+
+The spec checker found:
+${findings.length ? findings.map(f => '- ' + f).join('\n') : '- nothing'}
+
+The reader (given only the persona from plan.md, reading cold) said:
+${chadComments.length ? chadComments.map(f => '- ' + f).join('\n') : '- nothing'}
+
+Apply minimal, surgical edits — don't rebuild the page. plan.md is law for structure and doors; the reader is law for vocabulary and length. When the reader says a word needs explaining, gloss it in one line or cut it. When the reader says it's too long, cut the sentences the visual already says — never shrink the font or add a column; if it still doesn't fit, say so (splitting is a plan decision). Re-open the page in a browser at ${VIEWPORT} and confirm each point is resolved. Return one line per point: fixed / kept (with the reason) / could not fix and why.`
+
+phase('Build')
+const results = await pipeline(
+  pages,
+  p => agent(buildPrompt(p), { label: `build ${p.file}`, phase: 'Build' }),
+  (report, p) => parallel([
+    () => agent(checkPrompt(p, report || '(no report)'), { label: `check ${p.file}`, phase: 'Check', schema: CHECK_SCHEMA }),
+    () => agent(chadPagePrompt(p), { label: `chad ${p.file}`, phase: 'Check', schema: CHAD_SCHEMA }),
+  ]).then(([check, chad]) => ({ page: p.file, report, check, chad })),
+  async (r, p) => {
+    if (!r) return r
+    const findings = r.check?.pass === false ? (r.check.findings || []) : []
+    const comments = r.chad?.pass === false ? (r.chad.comments || []) : []
+    if (!findings.length && !comments.length) return r
+    const fix = await agent(fixPrompt(p, findings, comments), { label: `fix ${p.file}`, phase: 'Check' })
+    return { ...r, fix }
+  },
+)
+
+const built = results.filter(Boolean)
+const failed = built.filter(r => r.fix)
+const chadFlagged = built.filter(r => r.chad && !r.chad.pass)
+log(`${built.length}/${pages.length} pages built; ${failed.length} needed a fix pass (${chadFlagged.length} flagged by the reader)`)
+
+// Barrier is justified: dead links and orphans are only visible with the whole tree on disk.
+phase('Crawl')
+const crawl = await agent(`${GROUND}
+
+Crawl the finished explorable. Starting from ${DIR}/index.html, follow every same-folder .html link in a real browser (headless Chromium is fine). Report:
+- deadLinks: every href to a file that doesn't exist, as "from.html -> target.html"
+- orphans: every .html file in ${DIR} that no page links to (index.html excepted)
+- overflow: every page whose scrollHeight exceeds the viewport at ${VIEWPORT}, with the measured height
+- navIssues: any page whose breadcrumb, depth indicator or tree-map highlight is wrong or missing
+
+Compare the set of pages you reached against the tree in plan.md and list pages the plan has that don't exist as a dead link from their parent. Return only the data.`,
+  { label: 'crawl tree', phase: 'Crawl', schema: CRAWL_SCHEMA })
+
+const crawlFindings = [
+  ...(crawl?.deadLinks || []).map(s => `dead link: ${s}`),
+  ...(crawl?.orphans || []).map(s => `orphan: ${s}`),
+  ...(crawl?.overflow || []).map(s => `overflow: ${s}`),
+  ...(crawl?.navIssues || []).map(s => `nav: ${s}`),
+]
+
+let crawlFix = null
+if (crawlFindings.length) {
+  log(`${crawlFindings.length} crawl findings — fixing`)
+  crawlFix = await agent(`${GROUND}
+
+A whole-tree crawl found these problems:
+${crawlFindings.map(f => '- ' + f).join('\n')}
+
+Fix each with minimal edits, plan.md as law (a dead link whose target the plan lists means the page is missing — build it per its spec; a dead link the plan doesn't list means the href is wrong). Re-run the relevant check in a browser after each fix. Return one line per finding: fixed / could not fix and why.`,
+    { label: 'fix crawl findings', phase: 'Crawl' })
+} else {
+  log('crawl clean: no dead links, orphans, overflow or nav issues')
+}
+
+// The reader walks the whole tree in reading order — the only altitude where cross-page problems are visible.
+const walk = await agent(`${CHAD}
+
+Walk the whole explainer at ${DIR} the way a reader would: open ${DIR}/index.html in a real browser at ${VIEWPORT}, then follow doors top-down, branch by branch, until you have seen every page. Comment on what no single page can show:
+- the same term explained differently on different pages, or explained on one and assumed on another
+- a page that only makes sense if you read its sibling first
+- a child page that repeats its parent instead of going finer
+- a branch whose doors promised more than the pages delivered
+- anywhere the first page of a branch didn't tell you what the branch was for
+End with one bird's-eye comment on the whole thing: does it land for you, is it too long, is it in the right shape. Return pass=true only if nothing tripped you.`,
+  { label: 'chad walk (reading order)', phase: 'Crawl', schema: CHAD_SCHEMA })
+
+let walkFix = null
+if (walk && !walk.pass && walk.comments?.length) {
+  log(`${walk.comments.length} comments from the reader's walk — fixing`)
+  walkFix = await agent(`${GROUND}
+
+The reader (given only the persona from plan.md) walked the whole explainer in reading order and said:
+${walk.comments.map(c => '- ' + c).join('\n')}
+
+Address each with minimal edits across the pages involved — one gloss made consistent, a repeated paragraph cut, a branch's first page told what the branch is for. plan.md stays law for structure; the reader is law for vocabulary and length. Where a comment would need a structural change (new page, moved door), don't make it — report it for the human. Re-check edited pages in a browser at ${VIEWPORT} for overflow. Return one line per comment: fixed / kept (reason) / needs the human.`,
+    { label: 'fix walk comments', phase: 'Crawl' })
+} else {
+  log("reader's walk clean")
+}
+
+return {
+  dir: DIR,
+  pages: built.map(r => ({ file: r.page, pass: !!r.check?.pass, findings: r.check?.findings || [], chad: r.chad || null, fix: r.fix || null })),
+  checks: { built: built.length, planned: pages.length, fixed: failed.length, chadFlagged: chadFlagged.length },
+  crawl: crawl || null,
+  fixes: crawlFix,
+  walk: walk || null,
+  walkFixes: walkFix,
+}


### PR DESCRIPTION
## What

A new skill in the `creative` plugin: **explorable-explanation-creator**. Turns any topic, document, analysis or body of research into an Explorable Explanation — a tree of linked, no-scroll HTML pages where each page is the 80/20 of everything beneath it, the reader clicks into whatever they're curious about, and interactive JavaScript carries the ideas prose can't.

Files:
- `plugins/creative/skills/explorable-explanation-creator/SKILL.md` — four principles, format rules, the plan → gate → build process
- `references/plan-template.md` — the sign-off surface and the builders' law
- `references/mechanics.md` — interactive mechanics, for inspiration not as a menu
- `plugins/creative/workflows/explorable-build.js` — the build workflow (one builder per page → spec check + cold Chad reader → fixer → whole-tree crawl → Chad walk in reading order)
- README tree entry; creative plugin 1.4.0 → 1.5.0

## Why

One-page HTML explainers are dense by construction. This splits them into navigable depth and puts the creative energy where generation is cheap and direction is scarce: the plan. Two real builds (23 and 51 pages) shaped the rules — doors are words not addresses, the visual sets the height and prose fits beside it, the tree map is on demand, and a reviewer who has seen the spec reads as the builder, so Chad reads cold with only the persona.

## Notes

- Workflow path follows the repo convention (`${CLAUDE_PLUGIN_ROOT}/workflows/…`), same as `chief-of-staff/briefing`.
- Supersedes the unshipped `russian-doll-explanation` draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
