### PR TITLE
explorable-explanations: at most one idea per page, not exactly one

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explorable-explanations
-description: Build an explorable explanation — a tree of short, visual, single-viewport web pages (HTML+CSS+JS) that explains a topic one idea per page, where depth is expressed as navigation rather than scrolling, in the tradition of Nicky Case and Bret Victor. Use this whenever the user wants to explain, teach, or make someone understand a concept, system, piece of research, framework, or argument as a set of interlinked pages instead of one long scrolling page; says "explorable", "explorable explanation", "interactive explainer", "learn by playing", "playable essay", "Nicky Case style", "Parable of the Polygons style", or "like Bret Victor"; or asks for a website/one-pager that teaches something and would benefit from being split into a tree. Also use it to turn an existing article, paper, lecture, or mental model into something a reader can navigate at their own depth. Uses subagents where they pay off (a visual advisor, a builder per playable, independent clean-slate reviewers).
+description: Build an explorable explanation — a tree of short, visual, single-viewport web pages (HTML+CSS+JS) that explains a topic a page at a time, where depth is expressed as navigation rather than scrolling, in the tradition of Nicky Case and Bret Victor. Use this whenever the user wants to explain, teach, or make someone understand a concept, system, piece of research, framework, or argument as a set of interlinked pages instead of one long scrolling page; says "explorable", "explorable explanation", "interactive explainer", "learn by playing", "playable essay", "Nicky Case style", "Parable of the Polygons style", or "like Bret Victor"; or asks for a website/one-pager that teaches something and would benefit from being split into a tree. Also use it to turn an existing article, paper, lecture, or mental model into something a reader can navigate at their own depth. Uses subagents where they pay off (a visual advisor, a builder per playable, independent clean-slate reviewers).
 ---
 
 # Explorable Explanations
@@ -9,8 +9,9 @@ When someone asks for a beautiful HTML page that explains a piece of research, t
 is one long scroll: everything the topic has to say, stacked, and the reader scrolls
 through all of it whether they care or not. An explorable explanation is the levelled-up
 alternative. The same explanation is split into a **tree of short pages**, each fitting one
-laptop viewport and carrying one idea, where every page is one step deeper into the rabbit
-hole than the page above it. The reader chooses which rabbit holes to follow. Depth is
+laptop viewport and carrying no more than one idea — an idea that needs room gets several
+pages, each taking a piece of it — where every page is one step deeper into the rabbit hole
+than the page above it. The reader chooses which rabbit holes to follow. Depth is
 navigation, not scrolling.
 
 A page is, by default, what a page in a good explanatory article is: a short piece of prose
@@ -139,7 +140,9 @@ carries reader state, so mid-tree links are shareable.
   still read as a clear, connected account of the topic. Visuals deepen; prose explains.
 - **Love the question first, end with the reader's own.** Hook needs no prior knowledge;
   each page picks up where its parent left off; every path ends with a proper close.
-- **One idea per viewport.** If it doesn't fit, it's two ideas or it's the wrong medium.
+- **At most one idea per viewport.** A page never holds two; an idea often takes several.
+  If it doesn't fit, either it's two ideas, or it's one that wants unfolding across pages,
+  or it's the wrong medium.
 - **Interaction where it earns its place.** A playable when operating the thing is the
   lesson; otherwise the visual that shows it best.
 - **Depth is navigation.** The ways forward from a page are obvious and say where they

--- a/plugins/creative/skills/explorable-explanations/references/build-guide.md
+++ b/plugins/creative/skills/explorable-explanations/references/build-guide.md
@@ -81,8 +81,8 @@ floor as body text — a label that needs to go under ~12px means the figure nee
 restructuring, not smaller type.
 
 **Length.** However much prose the idea needs, within the viewport — in practice a couple
-of short paragraphs beside a visual. If it won't fit, that's usually two ideas, or the
-visual is doing work the words should do (or vice versa).
+of short paragraphs beside a visual. If it won't fit, split it: sometimes into two ideas,
+more often into two pages that both serve the same idea.
 
 **The visual** is whatever the x-factor pass chose: an SVG, an `<img>`, a `<figure>` with a
 caption, a `<video>`, a canvas, or a playable. It lives in `.ex-stage`, scales to the box,

--- a/plugins/creative/skills/explorable-explanations/references/tree-design.md
+++ b/plugins/creative/skills/explorable-explanations/references/tree-design.md
@@ -1,7 +1,9 @@
 # Tree Design
 
 An explorable built with this skill is a **tree of pages**, not a scrolling document.
-Each page fits one viewport and carries exactly one idea. Depth is expressed as
+Each page fits one viewport and carries at most one idea — the limit is on density, not on
+how much room an idea may have. Give a big idea as many pages as it takes: an aspect each, a
+comparison drawn out properly, the case seen from a second angle. Depth is expressed as
 navigation: the further you travel from the root, the deeper into the rabbit hole you
 are. Branches let the tree adapt to what the reader cares about — Case's wished-for
 non-linear explorable — but branching is also where readers get lost, so the shape rules


### PR DESCRIPTION
The new version of the skill, diffed against what's on the default branch. Three files changed — one rule, applied everywhere it appears.

**Before:** each page carries exactly one idea; prose that doesn't fit means you have two ideas.

**After:** a page carries at most one idea, and an idea that needs room gets several pages, each taking a piece of it. The limit is on density, not on how much room an idea may have. Prose that won't fit now splits into two pages serving one idea as often as into two ideas.

| File | What moved |
|---|---|
| `SKILL.md` | Frontmatter description, the opening paragraph, and the "one idea per viewport" principle |
| `references/tree-design.md` | The tree's per-page rule, plus the licence to give a big idea an aspect per page |
| `references/build-guide.md` | The length rule for a page's prose |

Creative plugin bumped 1.6.0 → 1.6.1 in `plugin.json` and `marketplace.json`. No files added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)