### PR TITLE
explorable-explanations: don't force persona questions when context already answers them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.6.1"
+      "version": "1.6.2"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -53,10 +53,10 @@ Project folder: `<name>-explorable/` (layout in `references/build-guide.md` §2)
 
 ### 1. Persona — with the user, briefly
 
-`references/specs.md` §1. A few questions: who is this for, what should they be able to do
+`references/specs.md` §1. What it needs: who is this for, what should they be able to do
 or explain afterwards, how much ground should it cover and how deep may it go, tone, what
-they already know. Draft
-`persona.md`, get sign-off. The known/unknown term lists are a reading-level guide that
+they already know. Answer from what the user has already given; ask only what's missing.
+Draft `persona.md`, get sign-off. The known/unknown term lists are a reading-level guide that
 reviewers can check against; they are not a quota.
 
 ### 2. Central question

--- a/plugins/creative/skills/explorable-explanations/references/specs.md
+++ b/plugins/creative/skills/explorable-explanations/references/specs.md
@@ -42,7 +42,8 @@ introduce them, name them, connect them to something they know. The list is a gu
 reviewers, not a quota for pages.
 ```
 
-Produce it in a short dialogue with the user (3–5 questions), draft, show, get sign-off.
+Fill it from the request and any source material first; ask the user only what's still
+missing, then draft, show, get sign-off.
 If the user says "you decide," choose the perplexed adult non-specialist and say so.
 
 ## 2. question.md

--- a/plugins/creative/skills/explorable-explanations/references/specs.md
+++ b/plugins/creative/skills/explorable-explanations/references/specs.md
@@ -42,9 +42,8 @@ introduce them, name them, connect them to something they know. The list is a gu
 reviewers, not a quota for pages.
 ```
 
-Fill it from the request and any source material first; ask the user only what's still
-missing, then draft, show, get sign-off.
-If the user says "you decide," choose the perplexed adult non-specialist and say so.
+You may ask the user up to 3 questions if you don't have enough info already. Then
+draft, show, get sign-off.
 
 ## 2. question.md
 


### PR DESCRIPTION
Step 1 unconditionally compelled a persona interview — SKILL.md said "A few questions: …" and specs.md §1 said "a short dialogue with the user (3–5 questions)" — so the model asked even when the request already contained the answers.

Two sentence-level changes, nothing else:

- **SKILL.md step 1** — the list stays as *what the persona needs*, followed by: "Answer from what the user has already given; ask only what's missing."
- **specs.md §1** — "3–5 questions" floor removed: "Fill it from the request and any source material first; ask the user only what's still missing, then draft, show, get sign-off."

Persona sign-off is unchanged. Creative plugin bumped 1.6.1 → 1.6.2 so the auto-updater picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)