### PR TITLE
explorable-explanations: make the tree the explicit design object

### DIFF
--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explorable-explanations
-description: Build an explorable explanation — a tree of short, visual, single-viewport web pages (HTML+CSS+JS) that explains a topic a page at a time, where depth is expressed as navigation rather than scrolling, in the tradition of Nicky Case and Bret Victor. Use this whenever the user wants to explain, teach, or make someone understand a concept, system, piece of research, framework, or argument as a set of interlinked pages instead of one long scrolling page; says "explorable", "explorable explanation", "interactive explainer", "learn by playing", "playable essay", "Nicky Case style", "Parable of the Polygons style", or "like Bret Victor"; or asks for a website/one-pager that teaches something and would benefit from being split into a tree. Also use it to turn an existing article, paper, lecture, or mental model into something a reader can navigate at their own depth. Uses subagents where they pay off (a visual advisor, a builder per playable, independent clean-slate reviewers).
+description: Build an explorable explanation — a tree of short, visual, single-viewport web pages (HTML+CSS+JS) that explains a topic a page at a time, where depth is expressed as navigation rather than scrolling, in the tradition of Nicky Case and Bret Victor. Use this whenever the user wants to explain, teach, or make someone understand a concept, system, piece of research, framework, or argument as a set of interlinked pages instead of one long scrolling page; says "explorable", "explorable explanation", "interactive explainer".
 ---
 
 # Explorable Explanations
@@ -23,7 +23,7 @@ explanation comes first; everything else serves it.
 
 Read `references/playbook.md` before your first project. It is the *why* — Case's arc,
 Victor's ladder, Strogatz's empathy — and you'll apply it with better judgment than any
-checklist. `references/design-patterns.md` is the menu of what can carry a page, and how to
+checklist. `references/design-patterns.md` is a sample menu of what can carry a page, and how to
 design a playable when a page gets one.
 
 ## How it goes
@@ -33,16 +33,18 @@ tree read as one piece, so the storyboard, the prose, and the pages are yours. S
 are for the few things that benefit from a separate context: an advisor on visuals, a
 builder for each playable, and reviewers who must not have seen your intent.
 
-**Persona.** Ask the user a few questions — who this is for, what they should be able to do
+1. **Persona.** Ask the user a few questions — who this is for, what they should be able to do
 or explain afterwards, how much ground to cover and how deep, tone, what they already know
 and don't. Write it down; get sign-off. The known/unknown terms are what let a reviewer
 check reading level against something concrete.
 
-**Question.** Come up with three candidates — a blatant question, a story, a game — each with
+2. **Question.** Start with 🤔. Make the reader love the question before you answer it (Strogatz). 
+Traditional teaching fails because "it answers questions the student hasn't thought to ask."
+Come up with three candidates — a blatant question, a story, a game — each with
 a sketch of page 1. Pick the one this reader would actually want answered, whose first page
 needs nothing they don't already know. Show the user.
 
-**Storyboard.** This is the step that decides whether the explorable teaches. Think as a
+3. **Storyboard.** This is the step that decides whether the explorable teaches. Think as a
 teacher, not a widget designer. Outline how you'd teach this subject to this reader — the way
 you'd outline a book: the areas the subject divides into, what each contains, how far each
 goes, down to the pages. What do they already believe that is wrong, and where does it get
@@ -54,25 +56,28 @@ something it didn't answer, and a division is two questions the reader chooses b
 the reader want each one before you answer it; every question you open is either answered
 somewhere in the tree or deliberately left as theirs.
 
-The tree's shape is the subject's, not a story's: a subject with six areas has a root with
-six children. A few things hold it together — every page has one parent; the root doesn't
-divide (the reader needs the hook and a first concrete idea before choosing a direction
-means anything); a page builds only on what its ancestors explained, never on a sibling
-subtree; and every leaf closes properly, so a reader who reaches the end of a path feels they
-arrived somewhere.
+Did you notice you are designing a tree here? Every page has one parent and 0 or more child pages that it links to.
 
-Have independent reviewers read the storyboard (below). An outline is cheap to change; fix
+Be deliberate about designing that tree well. A few guidelines on designing a good tree:
+
+- tree shape should match the topic at hand - is it a bushy tree with lots of branches and sub-branches or is it a straight tree with a main spine and short branches? is it a big tree or a small tree? you don't want an unnaturally shaped tree - too heavy on one side or one where branches start right from the root node.
+- a page builds only on what its ancestors explained, never on a sibling branch
+- every leaf closes properly, so a reader who reaches the end of a path feels they arrived somewhere
+- try not to have more than 3 branches at any given node 
+- every branch should feel natural
+
+The job is to design the explainer tree.
+
+4. Have independent reviewers read the storyboard. An outline is cheap to change; fix
 the teaching here, not in HTML.
 
 **What carries each page.** Read `references/design-patterns.md`, then go page by page and
 choose the right medium for that page's idea. Where a page gets a playable, do the
-message→mechanics exercise there. Then spawn an advisor with the persona and the storyboard
+message→mechanics exercise there. Then spawn an independent advisor agent with the persona and the storyboard
 to suggest stronger figures, better media, playables worth building, and things to cut; it
 advises, you decide.
 
-**Build.** Load the `frontend-design` skill and decide the visual identity for this subject
-before touching a page — every page of the tree shares it. Then build the pages yourself, in
-one pass: the prose in the persona's voice, with the connective tissue that makes the tree
+5. **Build.** Spawn an independent subagent with the `frontend-design` skill and let it come up with an interesting visual identity for this subject before touching a page — every page of the tree shares this visual language. Then build the pages yourself, in one pass: the prose in the persona's voice, with the connective tissue that makes the tree
 read as one argument, and the visual on each page. Give each playable its own subagent with
 the page's prose already written; it fills the visual and may flag a sentence that no longer
 matches, but it doesn't rewrite the explanation.
@@ -82,12 +87,14 @@ a figure that fits at 390px isn't the same as one that's legible there. The ways
 from a page are obvious and say where they lead; readers can always see where they are in
 the tree. Look at every page, at both sizes, before you call it done.
 
-**Review.** Spawn the six reviewers in `agents/` as separate subagents. Each gets only the
+Links to child pages on any given page should feel natural. instead of showing buttons and literally asking user to click on the one that they want to go deeper on, place the links in a part of a diagram that the user may naturally want to click into. Or on a piece of text they want to click into. Buttons are not banned but they I encourage you to find more interesting places. And always make sure it is styled so it's recognisably a way in.
+
+6. **Review.** Spawn the six reviewers in `agents/` as separate subagents. Each gets only the
 persona, its brief, and the built project — not your storyboard notes, your reasoning, or
 each other's findings. Fix what they find; run them again on what changed. Run the
 playtester, wayfinding and SME reviewers on the storyboard too, before building.
 
-**Deliver.** The project folder, a short tour, the persona, and what you chose not to fix
+7. **Deliver.** The project folder, a short tour, the persona, and what you chose not to fix
 and why.
 
 ## Lessons from real runs


### PR DESCRIPTION
Nityesh's edits to the skill, pushed as-is.

**The tree.** The storyboard step described tree shape in prose. It now names the tree as the thing being designed and gives guidelines an agent can check itself against: shape matches the topic, at most three branches per node, no branch straight off the root, every branch feels natural.

**Steps are numbered.** Persona → Question → Storyboard → review → Build → Review → Deliver now reads as a sequence instead of seven bold headings.

**More work goes to independent subagents.** The visual identity comes from a subagent running `frontend-design` rather than the skill being loaded inline, and the storyboard advisor is explicitly independent.

**Links.** Child pages should be reachable through a diagram or a phrase the reader already wants to click. Buttons aren't banned, just no longer the default.

**Description.** Trimmed to three trigger phrases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)