### PR TITLE
Bump creative plugin to 1.8.0 for the explorable-explanations tree rework

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.7.0"
+      "version": "1.8.0"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Claude Home Base"
   }


### PR DESCRIPTION
Follow-up to #42, which shipped without a version bump.

`plugins/creative/.claude-plugin/plugin.json` and the `creative` entry in `.claude-plugin/marketplace.json` both go 1.7.0 → 1.8.0.

Minor rather than patch: #42 restructured the storyboard step around tree design and moved the visual identity to a subagent. The recent patch bumps (1.6.1, 1.6.2) were single-guideline wording tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)