### PR TITLE
explorable-explanations: show child links as bad / good / great (1.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.8.0"
+      "version": "1.8.1"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -87,7 +87,13 @@ a figure that fits at 390px isn't the same as one that's legible there. The ways
 from a page are obvious and say where they lead; readers can always see where they are in
 the tree. Look at every page, at both sizes, before you call it done.
 
-Links to child pages on any given page should feel natural. instead of showing buttons and literally asking user to click on the one that they want to go deeper on, place the links in a part of a diagram that the user may naturally want to click into. Or on a piece of text they want to click into. Buttons are not banned but they I encourage you to find more interesting places. And always make sure it is styled so it's recognisably a way in.
+Links to child pages on any given page should feel natural. 
+
+Bad: Make a row at the bottom with buttons that ask users to click on it to go to "this room" or "open that door".
+Good: Weaving links as a natural part of a diagram that the user may naturally want to click into or a piece of prose. 
+Great: Links don't stand out shouting at the reader "click me" but rather silently exist as if predicting what the reader will be curious about next.
+
+And always make sure links are styled so it's obvious that they are meant to be clicked.
 
 6. **Review.** Spawn the six reviewers in `agents/` as separate subagents. Each gets only the
 persona, its brief, and the built project — not your storyboard notes, your reasoning, or


### PR DESCRIPTION
Nityesh's edit. The paragraph on where child-page links should live becomes three graded examples — a button row at the bottom (bad), links woven into a diagram or prose (good), links that read as if they predicted the reader's next question (great) — plus the standing rule that they're styled to look clickable.

Creative plugin 1.8.0 → 1.8.1 in `plugin.json` and the marketplace entry. Patch: one paragraph, no structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)