### PR TITLE
explorable-explanations: storyboard revision via independent consultant subagent (1.10.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.10.3"
+      "version": "1.10.4"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -70,16 +70,9 @@ Spawn the four reviewers in `agents/` (Chad, the curious kid, the restless reade
 on the storyboard, each with only the persona, its brief, and the storyboard. Read the
 "Review" step below for how to take what they say.
 
-Then revise the storyboard by incorporating the feedback. Go back to step 3 as a teacher with
-everything you now know: where the restless reader closed the tab, what the kid asked that
-nobody answered, what Chad couldn't say back, what the SME says is false. Think from a
-high-level about what the all the feedback mean at a high level and understand the feedback
-behind the feedback. Feel free to start the storyboard from scratch, add new pages or entire 
-branches, throw away pages or branches, rewrite
-them, split them, re-design the tree, change the question. 
+Then revise the storyboard by calling another independent consultant subagent whose job is to analyze all the feedback, the current storyboard and suggest high level architectural changes to the storyboard. It needs to think at a high level, identify patterns in the feedback, think of root cause issues and understand the feedback behind the feedback. Tell it that it has the freedom to suggest big structural changes like adding/cutting new pages or entire branches, throwing away ideas, taking a different path to teach something, split a branch or even start the whole process from scratch.
 
-Then call the reviewers again on storyboard v2 and revise it once again because this is the cheapest
-place to fix the plan before we go into the build phase. It only gets more expensive to fix after this.
+Implement the changes as suggested by the independent consultant. 
 
 5. **What carries each page.** Read `references/design-patterns.md`, then go page by page and
 choose the right medium for that page's idea. Where a page gets a playable, do the


### PR DESCRIPTION
Nityesh's edit to step 4. The orchestrator no longer revises the storyboard itself. It spawns an independent consultant subagent that reads all the feedback and the storyboard, finds patterns and root causes, and suggests high-level structural changes: add or cut pages or branches, throw away ideas, take a different teaching path, split a branch, or start from scratch. The orchestrator implements what the consultant suggests. The second reviewer round on storyboard v2 from #51 is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)