### PR TITLE
Define explorable quality dimensions and require a scripted reader journey

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.11.1"
+      "version": "1.11.2"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -16,8 +16,9 @@ Build a dense interconnected tree of short HTML slide decks, shaped like the top
 ## Working rhythm
 
 - Go through the documentation for the topic first.
-- Before building, write a detailed, fleshed-out `plan.md` like a scriptwriter scripting the whole reader experience: the opening hook, key passages of writing, what the reader sees, does, and discovers, and how they travel through the branches and transitions. Show what draws them onward and how the journey builds toward the intended learning outcome. Use the `frontend-design` skill for the UI.
+- Before building, write a detailed, fleshed-out `plan.md` like a scriptwriter scripting the whole reader experience: the opening hook, key passages of writing, what the reader sees, does, and discovers, and how they travel through the branches and transitions. Show what draws them onward and how the journey builds toward the intended learning outcome.
+- Use the `frontend-design` skill for the UI.
 - Pause and show the first batch before doing the rest.
 - Then build out the rest of the explorable.
 - Screenshot every slide and rework any that fails the craft rules.
-- Afterwards, use an adversarial subagent to judge the whole experience across Writing, UI, Visuals, and Teaching, find violations against the craft doc, and flag items to fix.
+- Afterwards, use a few adversarial subagents to judge the whole experience across Writing, UI, Visuals, and Teaching, find violations against the craft doc, and flag items to fix.

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -16,8 +16,8 @@ Build a dense interconnected tree of short HTML slide decks, shaped like the top
 ## Working rhythm
 
 - Go through the documentation for the topic first.
-- Make a plan before building, and use the `frontend-design` skill for the UI.
+- Before building, write a detailed, fleshed-out `plan.md` like a scriptwriter scripting the whole reader experience: the opening hook, key passages of writing, what the reader sees, does, and discovers, and how they travel through the branches and transitions. Show what draws them onward and how the journey builds toward the intended learning outcome. Use the `frontend-design` skill for the UI.
 - Pause and show the first batch before doing the rest.
 - Then build out the rest of the explorable.
 - Screenshot every slide and rework any that fails the craft rules.
-- Afterwards, use an adversarial subagent to find violations across the whole experience against the craft doc and flag items to fix.
+- Afterwards, use an adversarial subagent to judge the whole experience across Writing, UI, Visuals, and Teaching, find violations against the craft doc, and flag items to fix.

--- a/plugins/creative/skills/explorable-explanations/references/explorable-craft.md
+++ b/plugins/creative/skills/explorable-explanations/references/explorable-craft.md
@@ -4,6 +4,13 @@ The craft of building a great explorable explanation: practical lessons and thin
 
 You are building an immersive experience, a maze, a rabbit hole for the curious reader to get lost in. This is not simply breaking an article into slides. Inspired by Nicky Case, we are taking the idea one level further: a non-linear tree whose structure is a fingerprint of the topic.
 
+## Four dimensions of quality
+
+- **Writing:** Grab the reader’s attention from the start and sustain a natural flow that makes them want to turn the next page.
+- **UI:** Make the interface feel fresh, creative, and carefully considered, with attention to every detail.
+- **Visuals:** Make every playable, diagram, animation, and sandbox well-crafted, easy to understand, and useful in teaching the idea it serves.
+- **Teaching:** Understand where the reader starts, anticipate their confusions, and shape the whole journey around what they should understand or be able to do by the end.
+
 ## Form
 
 Give each slide one clear idea and enough room for the reader to absorb it.


### PR DESCRIPTION
Define Writing, UI, Visuals, and Teaching near the top of the explorable craft reference, with one sentence describing each dimension. Make the final review explicitly assess all four.

Expand the second working-rhythm step to require a detailed `plan.md` that scripts the whole reader experience: hooks, key writing, what readers see/do/discover, their paths through branches and transitions, and how the journey builds toward the intended learning outcome.

Bump the creative plugin to 1.11.2 in both manifests.

Validation: skill validator and `git diff --check` passed; plugin and marketplace versions match.
