### PR TITLE
explorable-explanations: add a final creative-director pass for visual identity (1.11.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.11.2"
+      "version": "1.11.3"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -22,3 +22,19 @@ Build a dense interconnected tree of short HTML slide decks, shaped like the top
 - Then build out the rest of the explorable.
 - Screenshot every slide and rework any that fails the craft rules.
 - Afterwards, use a few adversarial subagents to judge the whole experience across Writing, UI, Visuals, and Teaching, find violations against the craft doc, and flag items to fix.
+- At the very end, launch a separate subagent to give it a visual identity that’s as memorable as the experience itself with the instructions as given below:
+
+```
+Launch a separate subagent to act as a creative director. Have it review the code and visually inspect a few key pages, including the playables. Assume the structure, teaching, and writing are already excellent. Its job is to bring personality to the design.
+
+Ask it to propose a few creative directions that feel specific to this topic. Think at two scales:
+
+- The overall experience: like color, typography, backgrounds, texture, illustration style, motion, and recurring visual motifs that make everything feel part of the same world.
+- Individual slides or groups of slides: distinctive treatments for key pages—an expressive character, a surprising SVG illustration, a playful background, a mascot, or a small visual joke that makes an idea stick.
+
+Give it permission to be a radical design thinker with a tasteful restraint. What could make someone recognize this explorable from a single screenshot? Consider shaders or 3D effects combined with images where they would make the experience more interesting. It can use the openai-imagegen skill for image generation.
+
+Keep the clarity and ease of use that already work. Let the personality come from the subject and the experience of learning it.
+
+Have the creative director recommend its strongest ideas, with concrete examples of how it would transform a few existing pages. I want to be able to picture the result.
+```


### PR DESCRIPTION
Adds a last step to the explorable-explanations workflow: after the adversarial judges, launch a separate creative-director subagent to give the explorable a memorable visual identity. The step ships with the full prompt inline, covering two scales (the whole experience and individual slides), with permission to use shaders/3D/generated images while keeping the existing clarity.

Also bumps the creative plugin to 1.11.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)