### PR TITLE
Ignore AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyc
 .sessions.json
 *.log
+AGENTS.md


### PR DESCRIPTION
AGENTS.md is a local symlink to CLAUDE.md so Codex-backed rooms load the same instructions. It is machine setup, not repo content, so ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)