### PR TITLE
explorable-explanations: add optional Chad narrative-flow review (1.11.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "creative",
       "source": "./plugins/creative",
       "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-      "version": "1.11.3"
+      "version": "1.11.4"
     },
     {
       "name": "more-ai",

--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -38,3 +38,17 @@ Keep the clarity and ease of use that already work. Let the personality come fro
 
 Have the creative director recommend its strongest ideas, with concrete examples of how it would transform a few existing pages. I want to be able to picture the result.
 ```
+
+- Optionally, if the user reports that the narritive flow is breaking or the explorable is too dense at some points, launch a subagent to identify gaps in the flow with the instructions as given below:
+
+```
+Launch a separate subagent whose job is to review the narrative flow of this whole explorable.
+
+it needs to put itself in the shoes of a reader going through the material - say someone called Chad who is an impatient but curious teenager, he doesn't hate spending time on something but it needs to keep him engaged.
+
+it needs to put itself in the shoes of a reader and point out all the slides when the flow gets disturbed - material goes too fast, or jumps to a new idea without setting the expectation or building up properly or curiosity gap wasn't established, maybe a slide jumps onto the next with no connection, or maybe it is too dense or maybe a concept didn't the time it deserved and it leaves Chad hungry to learn more about it or a promise made in an earlier slide goes unfulfilled.
+
+so he's going to go through all the slides (just ask her to view the code) and give us pointed, blunt, specific feedback on any slide that doesn't work for him and why. he doesn't suggest solutions only specific problems and he doesn't mince his words.
+```
+
+- Once its review is in, realize that Chad just did us a big service. It gives us an opportunity to massively improve and enrich the reader experience even further. Lets do an awesome job at filling in these gaps and build a version 2.0 here. Feel free to use subagents to distribute the work.


### PR DESCRIPTION
Adds an optional step to the explorable-explanations skill. It runs when a user reports that the narrative flow breaks or a stretch feels too dense.

- A subagent reads the whole explorable as Chad, an impatient but curious teenager.
- Chad flags each slide where the flow breaks, with blunt, specific problems and no solutions.
- The main agent then fills those gaps and builds a 2.0, using subagents if useful.

Bumps the creative plugin to 1.11.4 in `plugin.json` and `marketplace.json` so the auto-updater picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)