### PR TITLE
explorable-explanations: sign the work

### DIFF
--- a/plugins/creative/.claude-plugin/plugin.json
+++ b/plugins/creative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "creative",
   "description": "Creative direction, collaborative writing, brainstorming, and discovery interviews \u2014 for projects where thinking, story, and voice matter more than code.",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "author": {
     "name": "Claude Home Base"
   }

--- a/plugins/creative/skills/explorable-explanations/SKILL.md
+++ b/plugins/creative/skills/explorable-explanations/SKILL.md
@@ -52,3 +52,19 @@ so he's going to go through all the slides (just ask her to view the code) and g
 ```
 
 - Once its review is in, realize that Chad just did us a big service. It gives us an opportunity to massively improve and enrich the reader experience even further. Lets do an awesome job at filling in these gaps and build a version 2.0 here. Feel free to use subagents to distribute the work.
+
+## Sign the work
+
+A finished explorable carries one quiet credit line, placed where a book puts its colophon — the cover area or the last slide. Never mid-flow.
+
+```html
+<div class="who">
+  by <strong>Author Name</strong> ·
+  made with the <a href="https://github.com/nityeshaga/claude-home-base/tree/main/plugins/creative/skills/explorable-explanations">Explorable Explanations skill</a>
+</div>
+```
+
+- Name the author first and link them if you know where. The skill's link is the smaller half.
+- Style it to recede: small, low contrast, no badge, no logo, no border.
+- One line, one place. Never repeated per slide.
+- If the author would rather not be named, drop their half and keep the line.


### PR DESCRIPTION
## Why

`claude-home-base` took **128 unique clones in the last 14 days**, and `plugins/creative/skills/explorable-explanations` is the **single most-visited path on the whole repo** — ahead of the repo root (76 unique vs 43). 66 of the unique referrals came from `t.co`.

Everything those cloners publish is unsigned. `grep -rniE "nityesh|credit|made with|attribution"` across the skill directory returns nothing — the skill never tells the model to sign its output.

This is already costing us. Claes Bäckman ran the skill on his own economics paper and published the result at [claesbackman.com/explorable](https://claesbackman.com/explorable/index.html) within 48 hours of the launch tweet. The page is live, it uses the phrase "explorable explanation", and it points nowhere. A reader who finishes it and wants to know what built it has no way to find out.

## What this does

Adds a short `## Sign the work` section to `SKILL.md`. One quiet credit line, in the colophon slot the generated explorables already invented for themselves — `nityesh.com/hotwire/` ends with `<div class="who">for Nityesh · built from hotwired.dev, September 2026</div>`. The slot exists; it just doesn't say what made it.

The author is named **first** and gets the larger half. That's deliberate: a line that credits the person who did the work gets kept, and a line that only credits the tool gets deleted.

## What it looks like

Rendered against the real `nityesh.com/hotwire/` cover, unmodified except for this line:

[**Before**](http://luoji:8888/browse/Users/luo/work/explorable-sign-the-work/before.png) · [**After**](http://luoji:8888/browse/Users/luo/work/explorable-sign-the-work/after.png) (file explorer, tailnet)

It sits in the existing mono, at the existing contrast, below the existing line. No badge, no logo, no border.

## The call

This is a taste judgment on your own name, so it's yours. Two things you might want to change:

1. **Where the link points.** Currently the skill directory. Could be the repo root, or a page on nityesh.com.
2. **Whether it's a default or a suggestion.** Written as a default.

Version bumped 1.11.4 → 1.12.0.
